### PR TITLE
Priority Queue Code Cleanup

### DIFF
--- a/src/main/java/com/williamfiset/algorithms/datastructures/priorityqueue/BinaryHeap.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/priorityqueue/BinaryHeap.java
@@ -11,12 +11,6 @@ import java.util.List;
 
 public class BinaryHeap<T extends Comparable<T>> {
 
-  // The number of elements currently inside the heap
-  private int heapSize = 0;
-
-  // The internal capacity of the heap
-  private int heapCapacity = 0;
-
   // A dynamic list to track the elements inside the heap
   private List<T> heap = null;
 
@@ -34,14 +28,14 @@ public class BinaryHeap<T extends Comparable<T>> {
   // http://www.cs.umd.edu/~meesh/351/mount/lectures/lect14-heapsort-analysis-part.pdf
   public BinaryHeap(T[] elems) {
 
-    heapSize = heapCapacity = elems.length;
-    heap = new ArrayList<T>(heapCapacity);
+    int heapSize = elems.length;
+    heap = new ArrayList<T>(heapSize);
 
     // Place all element in heap
     for (int i = 0; i < heapSize; i++) heap.add(elems[i]);
 
     // Heapify process, O(n)
-    for (int i = Math.max(0, (heapSize / 2) - 1); i >= 0; i--) sink(i);
+    for (int i = Math.max(0, (heapSize / 2) - 1); i >= 0; i--) sink(i, heapSize);
   }
 
   // Priority queue construction, O(nlog(n))
@@ -52,18 +46,17 @@ public class BinaryHeap<T extends Comparable<T>> {
 
   // Returns true/false depending on if the priority queue is empty
   public boolean isEmpty() {
-    return heapSize == 0;
+    return size() == 0;
   }
 
   // Clears everything inside the heap, O(n)
   public void clear() {
-    for (int i = 0; i < heapCapacity; i++) heap.set(i, null);
-    heapSize = 0;
+    heap.clear();
   }
 
   // Return the size of the heap
   public int size() {
-    return heapSize;
+    return heap.size();
   }
 
   // Returns the value of the element with the lowest
@@ -82,7 +75,7 @@ public class BinaryHeap<T extends Comparable<T>> {
   // Test if an element is in heap, O(n)
   public boolean contains(T elem) {
     // Linear scan to check containment
-    for (int i = 0; i < heapSize; i++) if (heap.get(i).equals(elem)) return true;
+    for (int i = 0; i < size(); i++) if (heap.get(i).equals(elem)) return true;
     return false;
   }
 
@@ -92,15 +85,9 @@ public class BinaryHeap<T extends Comparable<T>> {
 
     if (elem == null) throw new IllegalArgumentException();
 
-    if (heapSize < heapCapacity) {
-      heap.set(heapSize, elem);
-    } else {
-      heap.add(elem);
-      heapCapacity++;
-    }
-
-    swim(heapSize);
-    heapSize++;
+    heap.add(elem);
+    int indexOfLastElem = size() - 1 ;
+    swim(indexOfLastElem);
   }
 
   // Tests if the value of node i <= node j
@@ -130,7 +117,7 @@ public class BinaryHeap<T extends Comparable<T>> {
   }
 
   // Top down node sink, O(log(n))
-  private void sink(int k) {
+  private void sink(int k, int heapSize) {
     while (true) {
       int left = 2 * k + 1; // Left  node
       int right = 2 * k + 2; // Right node
@@ -163,6 +150,7 @@ public class BinaryHeap<T extends Comparable<T>> {
   public boolean remove(T element) {
     if (element == null) return false;
     // Linear removal via search, O(n)
+    int heapSize = size();
     for (int i = 0; i < heapSize; i++) {
       if (element.equals(heap.get(i))) {
         removeAt(i);
@@ -176,19 +164,19 @@ public class BinaryHeap<T extends Comparable<T>> {
   private T removeAt(int i) {
     if (isEmpty()) return null;
 
-    heapSize--;
+    int indexOfLastElem = size() - 1;
     T removed_data = heap.get(i);
-    swap(i, heapSize);
+    swap(i, indexOfLastElem);
 
     // Obliterate the value
-    heap.set(heapSize, null);
+    heap.remove(indexOfLastElem);
 
     // Check if the last element was removed
-    if (i == heapSize) return removed_data;
+    if (i == indexOfLastElem) return removed_data;
     T elem = heap.get(i);
 
     // Try sinking element
-    sink(i);
+    sink(i, size());
 
     // If sinking did not work try swimming
     if (heap.get(i).equals(elem)) swim(i);
@@ -201,6 +189,7 @@ public class BinaryHeap<T extends Comparable<T>> {
   // Called this method with k=0 to start at the root
   public boolean isMinHeap(int k) {
     // If we are outside the bounds of the heap return true
+    int heapSize = size();
     if (k >= heapSize) return true;
 
     int left = 2 * k + 1;

--- a/src/main/java/com/williamfiset/algorithms/datastructures/priorityqueue/BinaryHeapQuickRemovals.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/priorityqueue/BinaryHeapQuickRemovals.java
@@ -16,12 +16,6 @@ import java.util.TreeSet;
 
 public class BinaryHeapQuickRemovals<T extends Comparable<T>> {
 
-  // The number of elements currently inside the heap
-  private int heapSize = 0;
-
-  // The internal capacity of the heap
-  private int heapCapacity = 0;
-
   // A dynamic list to track the elements inside the heap
   private List<T> heap = null;
 
@@ -45,8 +39,8 @@ public class BinaryHeapQuickRemovals<T extends Comparable<T>> {
   // http://www.cs.umd.edu/~meesh/351/mount/lectures/lect14-heapsort-analysis-part.pdf
   public BinaryHeapQuickRemovals(T[] elems) {
 
-    heapSize = heapCapacity = elems.length;
-    heap = new ArrayList<T>(heapCapacity);
+    int heapSize = elems.length;
+    heap = new ArrayList<T>(heapSize);
 
     // Place all element in heap
     for (int i = 0; i < heapSize; i++) {
@@ -55,7 +49,7 @@ public class BinaryHeapQuickRemovals<T extends Comparable<T>> {
     }
 
     // Heapify process, O(n)
-    for (int i = Math.max(0, (heapSize / 2) - 1); i >= 0; i--) sink(i);
+    for (int i = Math.max(0, (heapSize / 2) - 1); i >= 0; i--) sink(i, heapSize);
   }
 
   // Priority queue construction, O(nlog(n))
@@ -66,19 +60,18 @@ public class BinaryHeapQuickRemovals<T extends Comparable<T>> {
 
   // Returns true/false depending on if the priority queue is empty
   public boolean isEmpty() {
-    return heapSize == 0;
+    return size() == 0;
   }
 
   // Clears everything inside the heap, O(n)
   public void clear() {
-    for (int i = 0; i < heapCapacity; i++) heap.set(i, null);
-    heapSize = 0;
+    heap.clear();
     map.clear();
   }
 
   // Return the size of the heap
   public int size() {
-    return heapSize;
+    return heap.size();
   }
 
   // Returns the value of the element with the lowest
@@ -115,17 +108,11 @@ public class BinaryHeapQuickRemovals<T extends Comparable<T>> {
 
     if (elem == null) throw new IllegalArgumentException();
 
-    if (heapSize < heapCapacity) {
-      heap.set(heapSize, elem);
-    } else {
-      heap.add(elem);
-      heapCapacity++;
-    }
+    heap.add(elem);
+    int indexOfLastElem = size() - 1;
+    mapAdd(elem, indexOfLastElem);
 
-    mapAdd(elem, heapSize);
-
-    swim(heapSize);
-    heapSize++;
+    swim(indexOfLastElem);
   }
 
   // Tests if the value of node i <= node j
@@ -157,7 +144,7 @@ public class BinaryHeapQuickRemovals<T extends Comparable<T>> {
   }
 
   // Top down node sink, O(log(n))
-  private void sink(int k) {
+  private void sink(int k, int heapSize) {
 
     while (true) {
 
@@ -215,21 +202,21 @@ public class BinaryHeapQuickRemovals<T extends Comparable<T>> {
 
     if (isEmpty()) return null;
 
-    heapSize--;
+    int indexOfLastElem = size() - 1;
     T removed_data = heap.get(i);
-    swap(i, heapSize);
+    swap(i, indexOfLastElem);
 
     // Obliterate the value
-    heap.set(heapSize, null);
-    mapRemove(removed_data, heapSize);
+    heap.remove(indexOfLastElem);
+    mapRemove(removed_data, indexOfLastElem);
 
     // Removed last element
-    if (i == heapSize) return removed_data;
+    if (i == indexOfLastElem) return removed_data;
 
     T elem = heap.get(i);
 
     // Try sinking element
-    sink(i);
+    sink(i, size());
 
     // If sinking did not work try swimming
     if (heap.get(i).equals(elem)) swim(i);
@@ -244,6 +231,7 @@ public class BinaryHeapQuickRemovals<T extends Comparable<T>> {
   public boolean isMinHeap(int k) {
 
     // If we are outside the bounds of the heap return true
+    int heapSize = size();
     if (k >= heapSize) return true;
 
     int left = 2 * k + 1;


### PR DESCRIPTION
**Issue:** 
BinaryHeap.java and BinaryHeapQuickRemovals.java classes are using the List interface to create Binary Heaps and also using two separate variables to maintain the size and capacity of the Binary Heap. 
Since the List interface maintains size and capacity internally, we do not have to maintain these external separate variables for the size and capacity of Binary Heap. 

**Fix:**
Cleaned up the code and removed the external variables used to maintain the size and capacity of Binary Heap.  