### PR TITLE
Update all JUnit and Jupiter assertions to use Google Truth assertions

### DIFF
--- a/src/test/java/com/williamfiset/algorithms/datastructures/balancedtree/AVLTreeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/balancedtree/AVLTreeTest.java
@@ -25,17 +25,17 @@ public class AVLTreeTest {
 
   @Test
   public void testNullInsertion() {
-    assertThat(tree.insert(null));
+    assertThat(tree.insert(null)).isFalse();
   }
 
   @Test
   public void testNullRemoval() {
-    assertThat(tree.remove(null));
+    assertThat(tree.remove(null)).isFalse();
   }
 
   @Test
   public void testTreeContainsNull() {
-    assertThat(tree.contains(null));
+    assertThat(tree.contains(null)).isFalse();
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/balancedtree/AVLTreeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/balancedtree/AVLTreeTest.java
@@ -1,6 +1,6 @@
 package com.williamfiset.algorithms.datastructures.balancedtree;
 
-import static org.junit.Assert.*;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -25,17 +25,17 @@ public class AVLTreeTest {
 
   @Test
   public void testNullInsertion() {
-    assertFalse(tree.insert(null));
+    assertThat(tree.insert(null));
   }
 
   @Test
   public void testNullRemoval() {
-    assertFalse(tree.remove(null));
+    assertThat(tree.remove(null));
   }
 
   @Test
   public void testTreeContainsNull() {
-    assertFalse(tree.contains(null));
+    assertThat(tree.contains(null));
   }
 
   @Test
@@ -45,14 +45,14 @@ public class AVLTreeTest {
     tree.insert(2);
     tree.insert(1);
 
-    assertEquals(2, tree.root.value.intValue());
-    assertEquals(1, tree.root.left.value.intValue());
-    assertEquals(3, tree.root.right.value.intValue());
+    assertThat(tree.root.value.intValue()).isEqualTo(2);
+    assertThat(tree.root.left.value.intValue()).isEqualTo(1);
+    assertThat(tree.root.right.value.intValue()).isEqualTo(3);
 
-    assertNull(tree.root.left.left);
-    assertNull(tree.root.left.right);
-    assertNull(tree.root.right.left);
-    assertNull(tree.root.right.right);
+    assertThat(tree.root.left.left).isNull();
+    assertThat(tree.root.left.right).isNull();
+    assertThat(tree.root.right.left).isNull();
+    assertThat(tree.root.right.right).isNull();
   }
 
   @Test
@@ -62,14 +62,14 @@ public class AVLTreeTest {
     tree.insert(1);
     tree.insert(2);
 
-    assertEquals(2, tree.root.value.intValue());
-    assertEquals(1, tree.root.left.value.intValue());
-    assertEquals(3, tree.root.right.value.intValue());
-
-    assertNull(tree.root.left.left);
-    assertNull(tree.root.left.right);
-    assertNull(tree.root.right.left);
-    assertNull(tree.root.right.right);
+    assertThat(tree.root.value.intValue()).isEqualTo(2);
+    assertThat(tree.root.left.value.intValue()).isEqualTo(1);
+    assertThat(tree.root.right.value.intValue()).isEqualTo(3);
+    
+    assertThat(tree.root.left.left).isNull();
+    assertThat(tree.root.left.right).isNull();
+    assertThat(tree.root.right.left).isNull();
+    assertThat(tree.root.right.right).isNull();
   }
 
   @Test
@@ -79,14 +79,14 @@ public class AVLTreeTest {
     tree.insert(2);
     tree.insert(3);
 
-    assertEquals(2, tree.root.value.intValue());
-    assertEquals(1, tree.root.left.value.intValue());
-    assertEquals(3, tree.root.right.value.intValue());
-
-    assertNull(tree.root.left.left);
-    assertNull(tree.root.left.right);
-    assertNull(tree.root.right.left);
-    assertNull(tree.root.right.right);
+    assertThat(tree.root.value.intValue()).isEqualTo(2);
+    assertThat(tree.root.left.value.intValue()).isEqualTo(1);
+    assertThat(tree.root.right.value.intValue()).isEqualTo(3);
+    
+    assertThat(tree.root.left.left).isNull();
+    assertThat(tree.root.left.right).isNull();
+    assertThat(tree.root.right.left).isNull();
+    assertThat(tree.root.right.right).isNull();
   }
 
   @Test
@@ -96,21 +96,21 @@ public class AVLTreeTest {
     tree.insert(3);
     tree.insert(2);
 
-    assertEquals(2, tree.root.value.intValue());
-    assertEquals(1, tree.root.left.value.intValue());
-    assertEquals(3, tree.root.right.value.intValue());
-
-    assertNull(tree.root.left.left);
-    assertNull(tree.root.left.right);
-    assertNull(tree.root.right.left);
-    assertNull(tree.root.right.right);
+    assertThat(tree.root.value.intValue()).isEqualTo(2);
+    assertThat(tree.root.left.value.intValue()).isEqualTo(1);
+    assertThat(tree.root.right.value.intValue()).isEqualTo(3);
+    
+    assertThat(tree.root.left.left).isNull();
+    assertThat(tree.root.left.right).isNull();
+    assertThat(tree.root.right.left).isNull();
+    assertThat(tree.root.right.right).isNull();
   }
 
   @Test
   public void testRandomizedBalanceFactorTest() {
     for (int i = 0; i < TEST_SZ; i++) {
       tree.insert(randValue());
-      assertTrue(validateBalanceFactorValues(tree.root));
+      assertThat(validateBalanceFactorValues(tree.root)).isTrue();
     }
   }
 
@@ -127,9 +127,10 @@ public class AVLTreeTest {
     TreeSet<Integer> set = new TreeSet<>();
     for (int i = 0; i < TEST_SZ; i++) {
       int v = randValue();
-      assertEquals(set.add(v), tree.insert(v));
-      assertEquals(set.size(), tree.size());
-      assertTrue(tree.validateBSTInvarient(tree.root));
+
+      assertThat(tree.insert(v)).isEqualTo(set.add(v));
+      assertThat(tree.size()).isEqualTo(set.size());
+      assertThat(tree.validateBSTInvarient(tree.root)).isTrue();
     }
   }
 
@@ -138,7 +139,7 @@ public class AVLTreeTest {
     for (int n = 1; n <= TEST_SZ; n++) {
 
       tree.insert(randValue());
-      int height = tree.height();
+      double height = tree.height();
 
       // Get an upper bound on what the maximum height of
       // an AVL tree should be. Values were taken from:
@@ -147,7 +148,7 @@ public class AVLTreeTest {
       double b = -0.329;
       double upperBound = c * (Math.log(n + 2.0) / Math.log(2)) + b;
 
-      assertTrue(height < upperBound);
+      assertThat(height).isLessThan(upperBound);
     }
   }
 
@@ -169,12 +170,12 @@ public class AVLTreeTest {
 
         Integer value = lst.get(j);
 
-        assertEquals(ts.remove(value), tree.remove(value));
-        assertFalse(tree.contains(value));
-        assertEquals(size - j - 1, tree.size());
+        assertThat(tree.remove(value)).isEqualTo(ts.remove(value));
+        assertThat(tree.contains(value)).isFalse();
+        assertThat(tree.size()).isEqualTo(size - j - 1);
       }
 
-      assertTrue(tree.isEmpty());
+      assertThat(tree.isEmpty()).isTrue();
     }
   }
 

--- a/src/test/java/com/williamfiset/algorithms/datastructures/balancedtree/AVLTreeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/balancedtree/AVLTreeTest.java
@@ -65,7 +65,7 @@ public class AVLTreeTest {
     assertThat(tree.root.value.intValue()).isEqualTo(2);
     assertThat(tree.root.left.value.intValue()).isEqualTo(1);
     assertThat(tree.root.right.value.intValue()).isEqualTo(3);
-    
+
     assertThat(tree.root.left.left).isNull();
     assertThat(tree.root.left.right).isNull();
     assertThat(tree.root.right.left).isNull();
@@ -82,7 +82,7 @@ public class AVLTreeTest {
     assertThat(tree.root.value.intValue()).isEqualTo(2);
     assertThat(tree.root.left.value.intValue()).isEqualTo(1);
     assertThat(tree.root.right.value.intValue()).isEqualTo(3);
-    
+
     assertThat(tree.root.left.left).isNull();
     assertThat(tree.root.left.right).isNull();
     assertThat(tree.root.right.left).isNull();
@@ -99,7 +99,7 @@ public class AVLTreeTest {
     assertThat(tree.root.value.intValue()).isEqualTo(2);
     assertThat(tree.root.left.value.intValue()).isEqualTo(1);
     assertThat(tree.root.right.value.intValue()).isEqualTo(3);
-    
+
     assertThat(tree.root.left.left).isNull();
     assertThat(tree.root.left.right).isNull();
     assertThat(tree.root.right.left).isNull();

--- a/src/test/java/com/williamfiset/algorithms/datastructures/balancedtree/RedBlackTreeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/balancedtree/RedBlackTreeTest.java
@@ -1,6 +1,5 @@
 package com.williamfiset.algorithms.datastructures.balancedtree;
 
-// import static org.junit.Assert.*;
 import static com.google.common.truth.Truth.assertThat;
 
 import java.util.*;
@@ -182,7 +181,6 @@ public class RedBlackTreeTest {
     assertThat(tree.root.left.left.color).isEqualTo(RedBlackTree.RED);
 
     assertThat(tree.root.right.left).isEqualTo(tree.NIL);
-
     assertThat(tree.root.left.right).isEqualTo(tree.NIL);
     assertNullChildren(tree, tree.root.right, tree.root.left.left);
     assertCorrectParentLinks(tree, tree.root, tree.NIL);

--- a/src/test/java/com/williamfiset/algorithms/datastructures/balancedtree/RedBlackTreeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/balancedtree/RedBlackTreeTest.java
@@ -1,6 +1,7 @@
 package com.williamfiset.algorithms.datastructures.balancedtree;
 
-import static org.junit.Assert.*;
+// import static org.junit.Assert.*;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.util.*;
 import org.junit.Before;
@@ -27,7 +28,7 @@ public class RedBlackTreeTest {
 
   @Test
   public void testTreeContainsNull() {
-    assertFalse(tree.contains(null));
+    assertThat(tree.contains(null)).isFalse();
   }
 
   @Test
@@ -37,16 +38,16 @@ public class RedBlackTreeTest {
     tree.insert(2);
     tree.insert(1);
 
-    assertEquals(2, tree.root.value.intValue());
-    assertEquals(1, tree.root.left.value.intValue());
-    assertEquals(3, tree.root.right.value.intValue());
+    assertThat(tree.root.value.intValue()).isEqualTo(2);
+    assertThat(tree.root.left.value.intValue()).isEqualTo(1);
+    assertThat(tree.root.right.value.intValue()).isEqualTo(3);
 
-    assertEquals(RedBlackTree.BLACK, tree.root.color);
-    assertEquals(RedBlackTree.RED, tree.root.left.color);
-    assertEquals(RedBlackTree.RED, tree.root.right.color);
+    assertThat(tree.root.color).isEqualTo(RedBlackTree.BLACK);
+    assertThat(tree.root.left.color).isEqualTo(RedBlackTree.RED);
+    assertThat(tree.root.right.color).isEqualTo(RedBlackTree.RED);
 
-    assertEquals(tree.root, tree.root.left.parent);
-    assertEquals(tree.root, tree.root.right.parent);
+    assertThat(tree.root).isEqualTo(tree.root.left.parent);
+    assertThat(tree.root).isEqualTo(tree.root.right.parent);
 
     assertNullChildren(tree, tree.root.left, tree.root.right);
     assertCorrectParentLinks(tree, tree.root, tree.NIL);
@@ -59,16 +60,16 @@ public class RedBlackTreeTest {
     tree.insert(1);
     tree.insert(2);
 
-    assertEquals(2, tree.root.value.intValue());
-    assertEquals(1, tree.root.left.value.intValue());
-    assertEquals(3, tree.root.right.value.intValue());
+    assertThat(tree.root.value.intValue()).isEqualTo(2);
+    assertThat(tree.root.left.value.intValue()).isEqualTo(1);
+    assertThat(tree.root.right.value.intValue()).isEqualTo(3);
 
-    assertEquals(RedBlackTree.BLACK, tree.root.color);
-    assertEquals(RedBlackTree.RED, tree.root.left.color);
-    assertEquals(RedBlackTree.RED, tree.root.right.color);
+    assertThat(tree.root.color).isEqualTo(RedBlackTree.BLACK);
+    assertThat(tree.root.left.color).isEqualTo(RedBlackTree.RED);
+    assertThat(tree.root.right.color).isEqualTo(RedBlackTree.RED);
 
-    assertEquals(tree.root, tree.root.left.parent);
-    assertEquals(tree.root, tree.root.right.parent);
+    assertThat(tree.root).isEqualTo(tree.root.left.parent);
+    assertThat(tree.root).isEqualTo(tree.root.right.parent);
 
     assertNullChildren(tree, tree.root.left, tree.root.right);
     assertCorrectParentLinks(tree, tree.root, tree.NIL);
@@ -81,16 +82,16 @@ public class RedBlackTreeTest {
     tree.insert(3);
     tree.insert(2);
 
-    assertEquals(2, tree.root.value.intValue());
-    assertEquals(1, tree.root.left.value.intValue());
-    assertEquals(3, tree.root.right.value.intValue());
+    assertThat(tree.root.value.intValue()).isEqualTo(2);
+    assertThat(tree.root.left.value.intValue()).isEqualTo(1);
+    assertThat(tree.root.right.value.intValue()).isEqualTo(3);
 
-    assertEquals(RedBlackTree.BLACK, tree.root.color);
-    assertEquals(RedBlackTree.RED, tree.root.left.color);
-    assertEquals(RedBlackTree.RED, tree.root.right.color);
+    assertThat(tree.root.color).isEqualTo(RedBlackTree.BLACK);
+    assertThat(tree.root.left.color).isEqualTo(RedBlackTree.RED);
+    assertThat(tree.root.right.color).isEqualTo(RedBlackTree.RED);
 
-    assertEquals(tree.root, tree.root.left.parent);
-    assertEquals(tree.root, tree.root.right.parent);
+    assertThat(tree.root).isEqualTo(tree.root.left.parent);
+    assertThat(tree.root).isEqualTo(tree.root.right.parent);
 
     assertNullChildren(tree, tree.root.left, tree.root.right);
     assertCorrectParentLinks(tree, tree.root, tree.NIL);
@@ -103,16 +104,16 @@ public class RedBlackTreeTest {
     tree.insert(2);
     tree.insert(3);
 
-    assertEquals(2, tree.root.value.intValue());
-    assertEquals(1, tree.root.left.value.intValue());
-    assertEquals(3, tree.root.right.value.intValue());
+    assertThat(tree.root.value.intValue()).isEqualTo(2);
+    assertThat(tree.root.left.value.intValue()).isEqualTo(1);
+    assertThat(tree.root.right.value.intValue()).isEqualTo(3);
 
-    assertEquals(RedBlackTree.BLACK, tree.root.color);
-    assertEquals(RedBlackTree.RED, tree.root.left.color);
-    assertEquals(RedBlackTree.RED, tree.root.right.color);
+    assertThat(tree.root.color).isEqualTo(RedBlackTree.BLACK);
+    assertThat(tree.root.left.color).isEqualTo(RedBlackTree.RED);
+    assertThat(tree.root.right.color).isEqualTo(RedBlackTree.RED);
 
-    assertEquals(tree.root, tree.root.left.parent);
-    assertEquals(tree.root, tree.root.right.parent);
+    assertThat(tree.root).isEqualTo(tree.root.left.parent);
+    assertThat(tree.root).isEqualTo(tree.root.right.parent);
 
     assertNullChildren(tree, tree.root.left, tree.root.right);
     assertCorrectParentLinks(tree, tree.root, tree.NIL);
@@ -128,17 +129,17 @@ public class RedBlackTreeTest {
     tree.insert(3);
     tree.insert(4);
 
-    assertEquals(2, tree.root.value.intValue());
-    assertEquals(1, tree.root.left.value.intValue());
-    assertEquals(3, tree.root.right.value.intValue());
-    assertEquals(4, tree.root.right.right.value.intValue());
+    assertThat(tree.root.value.intValue()).isEqualTo(2);
+    assertThat(tree.root.left.value.intValue()).isEqualTo(1);
+    assertThat(tree.root.right.value.intValue()).isEqualTo(3);
+    assertThat(tree.root.right.right.value.intValue()).isEqualTo(4);
 
-    assertEquals(RedBlackTree.BLACK, tree.root.color);
-    assertEquals(RedBlackTree.BLACK, tree.root.left.color);
-    assertEquals(RedBlackTree.BLACK, tree.root.right.color);
-    assertEquals(RedBlackTree.RED, tree.root.right.right.color);
+    assertThat(tree.root.color).isEqualTo(RedBlackTree.BLACK);
+    assertThat(tree.root.left.color).isEqualTo(RedBlackTree.BLACK);
+    assertThat(tree.root.right.color).isEqualTo(RedBlackTree.BLACK);
+    assertThat(tree.root.right.right.color).isEqualTo(RedBlackTree.RED);
 
-    assertEquals(tree.NIL, tree.root.right.left);
+    assertThat(tree.root.right.left).isEqualTo(tree.NIL);
     assertNullChildren(tree, tree.root.left, tree.root.right.right);
     assertCorrectParentLinks(tree, tree.root, tree.NIL);
 
@@ -146,17 +147,17 @@ public class RedBlackTreeTest {
 
     tree.insert(5);
 
-    assertEquals(2, tree.root.value.intValue());
-    assertEquals(1, tree.root.left.value.intValue());
-    assertEquals(4, tree.root.right.value.intValue());
-    assertEquals(3, tree.root.right.left.value.intValue());
-    assertEquals(5, tree.root.right.right.value.intValue());
+    assertThat(tree.root.value.intValue()).isEqualTo(2);
+    assertThat(tree.root.left.value.intValue()).isEqualTo(1);
+    assertThat(tree.root.right.value.intValue()).isEqualTo(4);
+    assertThat(tree.root.right.left.value.intValue()).isEqualTo(3);
+    assertThat(tree.root.right.right.value.intValue()).isEqualTo(5);
 
-    assertEquals(RedBlackTree.BLACK, tree.root.color);
-    assertEquals(RedBlackTree.BLACK, tree.root.left.color);
-    assertEquals(RedBlackTree.BLACK, tree.root.right.color);
-    assertEquals(RedBlackTree.RED, tree.root.right.left.color);
-    assertEquals(RedBlackTree.RED, tree.root.right.right.color);
+    assertThat(tree.root.color).isEqualTo(RedBlackTree.BLACK);
+    assertThat(tree.root.left.color).isEqualTo(RedBlackTree.BLACK);
+    assertThat(tree.root.right.color).isEqualTo(RedBlackTree.BLACK);
+    assertThat(tree.root.right.left.color).isEqualTo(RedBlackTree.RED);
+    assertThat(tree.root.right.right.color).isEqualTo(RedBlackTree.RED);
     assertCorrectParentLinks(tree, tree.root, tree.NIL);
   }
 
@@ -170,17 +171,19 @@ public class RedBlackTreeTest {
     tree.insert(4);
     tree.insert(1);
 
-    assertEquals(3, tree.root.value.intValue());
-    assertEquals(2, tree.root.left.value.intValue());
-    assertEquals(4, tree.root.right.value.intValue());
-    assertEquals(1, tree.root.left.left.value.intValue());
+    assertThat(tree.root.value.intValue()).isEqualTo(3);
+    assertThat(tree.root.left.value.intValue()).isEqualTo(2);
+    assertThat(tree.root.right.value.intValue()).isEqualTo(4);
+    assertThat(tree.root.left.left.value.intValue()).isEqualTo(1);
 
-    assertEquals(RedBlackTree.BLACK, tree.root.color);
-    assertEquals(RedBlackTree.BLACK, tree.root.left.color);
-    assertEquals(RedBlackTree.BLACK, tree.root.right.color);
-    assertEquals(RedBlackTree.RED, tree.root.left.left.color);
+    assertThat(tree.root.color).isEqualTo(RedBlackTree.BLACK);
+    assertThat(tree.root.left.color).isEqualTo(RedBlackTree.BLACK);
+    assertThat(tree.root.right.color).isEqualTo(RedBlackTree.BLACK);
+    assertThat(tree.root.left.left.color).isEqualTo(RedBlackTree.RED);
 
-    assertEquals(tree.NIL, tree.root.left.right);
+    assertThat(tree.root.right.left).isEqualTo(tree.NIL);
+
+    assertThat(tree.root.left.right).isEqualTo(tree.NIL);
     assertNullChildren(tree, tree.root.right, tree.root.left.left);
     assertCorrectParentLinks(tree, tree.root, tree.NIL);
 
@@ -188,17 +191,17 @@ public class RedBlackTreeTest {
 
     tree.insert(0);
 
-    assertEquals(3, tree.root.value.intValue());
-    assertEquals(1, tree.root.left.value.intValue());
-    assertEquals(4, tree.root.right.value.intValue());
-    assertEquals(0, tree.root.left.left.value.intValue());
-    assertEquals(2, tree.root.left.right.value.intValue());
+    assertThat(tree.root.value.intValue()).isEqualTo(3);
+    assertThat(tree.root.left.value.intValue()).isEqualTo(1);
+    assertThat(tree.root.right.value.intValue()).isEqualTo(4);
+    assertThat(tree.root.left.left.value.intValue()).isEqualTo(0);
+    assertThat(tree.root.left.right.value.intValue()).isEqualTo(2);
 
-    assertEquals(RedBlackTree.BLACK, tree.root.color);
-    assertEquals(RedBlackTree.BLACK, tree.root.left.color);
-    assertEquals(RedBlackTree.BLACK, tree.root.right.color);
-    assertEquals(RedBlackTree.RED, tree.root.left.left.color);
-    assertEquals(RedBlackTree.RED, tree.root.left.right.color);
+    assertThat(tree.root.color).isEqualTo(RedBlackTree.BLACK);
+    assertThat(tree.root.left.color).isEqualTo(RedBlackTree.BLACK);
+    assertThat(tree.root.right.color).isEqualTo(RedBlackTree.BLACK);
+    assertThat(tree.root.left.left.color).isEqualTo(RedBlackTree.RED);
+    assertThat(tree.root.left.right.color).isEqualTo(RedBlackTree.RED);
     assertCorrectParentLinks(tree, tree.root, tree.NIL);
   }
 
@@ -208,28 +211,28 @@ public class RedBlackTreeTest {
     int[] values = {41, 44, 95, 83, 72, 66, 94, 90, 59};
     for (int v : values) tree.insert(v);
 
-    assertEquals(44, tree.root.value.intValue());
+    assertThat(tree.root.value.intValue()).isEqualTo(44);
 
-    assertEquals(41, tree.root.left.value.intValue());
-    assertEquals(83, tree.root.right.value.intValue());
+    assertThat(tree.root.left.value.intValue()).isEqualTo(41);
+    assertThat(tree.root.right.value.intValue()).isEqualTo(83);
 
-    assertEquals(66, tree.root.right.left.value.intValue());
-    assertEquals(94, tree.root.right.right.value.intValue());
+    assertThat(tree.root.right.left.value.intValue()).isEqualTo(66);
+    assertThat(tree.root.right.right.value.intValue()).isEqualTo(94);
 
-    assertEquals(59, tree.root.right.left.left.value.intValue());
-    assertEquals(72, tree.root.right.left.right.value.intValue());
-    assertEquals(90, tree.root.right.right.left.value.intValue());
-    assertEquals(95, tree.root.right.right.right.value.intValue());
+    assertThat(tree.root.right.left.left.value.intValue()).isEqualTo(59);
+    assertThat(tree.root.right.left.right.value.intValue()).isEqualTo(72);
+    assertThat(tree.root.right.right.left.value.intValue()).isEqualTo(90);
+    assertThat(tree.root.right.right.right.value.intValue()).isEqualTo(95);
 
-    assertEquals(RedBlackTree.BLACK, tree.root.color);
-    assertEquals(RedBlackTree.BLACK, tree.root.left.color);
-    assertEquals(RedBlackTree.RED, tree.root.right.color);
-    assertEquals(RedBlackTree.BLACK, tree.root.right.left.color);
-    assertEquals(RedBlackTree.BLACK, tree.root.right.right.color);
-    assertEquals(RedBlackTree.RED, tree.root.right.left.left.color);
-    assertEquals(RedBlackTree.RED, tree.root.right.left.right.color);
-    assertEquals(RedBlackTree.RED, tree.root.right.right.left.color);
-    assertEquals(RedBlackTree.RED, tree.root.right.right.right.color);
+    assertThat(tree.root.color).isEqualTo(RedBlackTree.BLACK);
+    assertThat(tree.root.left.color).isEqualTo(RedBlackTree.BLACK);
+    assertThat(tree.root.right.color).isEqualTo(RedBlackTree.RED);
+    assertThat(tree.root.right.left.color).isEqualTo(RedBlackTree.BLACK);
+    assertThat(tree.root.right.right.color).isEqualTo(RedBlackTree.BLACK);
+    assertThat(tree.root.right.left.left.color).isEqualTo(RedBlackTree.RED);
+    assertThat(tree.root.right.left.right.color).isEqualTo(RedBlackTree.RED);
+    assertThat(tree.root.right.right.left.color).isEqualTo(RedBlackTree.RED);
+    assertThat(tree.root.right.right.right.color).isEqualTo(RedBlackTree.RED);    
   }
 
   @Test
@@ -238,9 +241,9 @@ public class RedBlackTreeTest {
     TreeSet<Integer> set = new TreeSet<>();
     for (int i = 0; i < TEST_SZ; i++) {
       int v = randValue();
-      assertEquals(set.add(v), tree.insert(v));
-      assertEquals(set.size(), tree.size());
-      assertTrue(tree.contains(v));
+      assertThat(tree.insert(v)).isEqualTo(set.add(v));
+      assertThat(tree.size()).isEqualTo(tree.size());
+      assertThat(tree.contains(v)).isTrue();
       assertBinarySearchTreeInvariant(tree, tree.root);
     }
   }
@@ -252,23 +255,23 @@ public class RedBlackTreeTest {
     tree.insert(9);
 
     tree.delete(5);
-    assertFalse(tree.contains(5));
+    assertThat(tree.contains(5)).isFalse();
 
     tree.delete(7);
-    assertFalse(tree.contains(7));
+    assertThat(tree.contains(7)).isFalse();
 
     tree.delete(9);
-    assertFalse(tree.contains(9));
+    assertThat(tree.contains(9)).isFalse();
   }
 
   @Test
   public void testNullRemoval() {
-    assertFalse(tree.delete(null));
+    assertThat(tree.delete(null)).isFalse();
   }
 
   @Test
   public void testNumberDoesntExist() {
-    assertFalse(tree.delete(0));
+    assertThat(tree.delete(0)).isFalse();
   }
 
   @Test
@@ -288,11 +291,11 @@ public class RedBlackTreeTest {
         Integer value = lst.get(j);
         boolean treeSetRemove = ts.remove(value);
         boolean treeRemove = tree.delete(value);
-        assertEquals(treeSetRemove, treeRemove);
-        assertFalse(tree.contains(value));
-        assertEquals(i - j - 1, tree.size());
+        assertThat(treeSetRemove).isEqualTo(treeRemove);
+        assertThat(tree.contains(value)).isFalse();
+        assertThat(tree.size()).isEqualTo(i - j - 1);
       }
-      assertEquals(ts.isEmpty(), tree.isEmpty());
+      assertThat(ts.isEmpty()).isEqualTo(tree.isEmpty());
     }
   }
 
@@ -301,20 +304,20 @@ public class RedBlackTreeTest {
     for (int n = 1; n <= TEST_SZ; n++) {
 
       tree.insert(randValue());
-      int height = tree.height();
+      double height = tree.height();
 
       // RB tree height upper bound:
       // https://en.wikipedia.org/wiki/AVL_tree#Comparison_to_other_structures
       double upperBound = 2 * (Math.log(n + 1) / Math.log(2));
 
-      assertTrue(height <= upperBound);
+      assertThat(height).isAtMost(upperBound);
     }
   }
 
   static void assertNullChildren(RedBlackTree tree, RedBlackTree.Node... nodes) {
     for (RedBlackTree.Node node : nodes) {
-      assertEquals(tree.NIL, node.left);
-      assertEquals(tree.NIL, node.right);
+      assertThat(node.left).isEqualTo(tree.NIL);
+      assertThat(node.right).isEqualTo(tree.NIL);
     }
   }
 
@@ -322,9 +325,9 @@ public class RedBlackTreeTest {
       RedBlackTree tree, RedBlackTree.Node node, RedBlackTree.Node parent) {
     if (node == tree.NIL) return;
     try {
-      assertEquals(node.parent, parent);
+      assertThat(node.parent).isEqualTo(parent);
     } catch (AssertionError e) {
-      System.out.println("hi");
+      e.printStackTrace();
     }
     assertCorrectParentLinks(tree, node.left, node);
     assertCorrectParentLinks(tree, node.right, node);

--- a/src/test/java/com/williamfiset/algorithms/datastructures/balancedtree/RedBlackTreeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/balancedtree/RedBlackTreeTest.java
@@ -230,7 +230,7 @@ public class RedBlackTreeTest {
     assertThat(tree.root.right.left.left.color).isEqualTo(RedBlackTree.RED);
     assertThat(tree.root.right.left.right.color).isEqualTo(RedBlackTree.RED);
     assertThat(tree.root.right.right.left.color).isEqualTo(RedBlackTree.RED);
-    assertThat(tree.root.right.right.right.color).isEqualTo(RedBlackTree.RED);    
+    assertThat(tree.root.right.right.right.color).isEqualTo(RedBlackTree.RED);
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/binarysearchtree/BinarySearchTreeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/binarysearchtree/BinarySearchTreeTest.java
@@ -1,6 +1,6 @@
 package com.williamfiset.algorithms.datastructures.binarysearchtree;
 
-import static org.junit.Assert.*;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -91,19 +91,19 @@ public class BinarySearchTreeTest {
   public void testIsEmpty() {
 
     BinarySearchTree<String> tree = new BinarySearchTree<>();
-    assertTrue(tree.isEmpty());
+    assertThat(tree.isEmpty()).isTrue();
 
     tree.add("Hello World!");
-    assertFalse(tree.isEmpty());
+    assertThat(tree.isEmpty()).isFalse();
   }
 
   @Test
   public void testSize() {
     BinarySearchTree<String> tree = new BinarySearchTree<>();
-    assertEquals(tree.size(), 0);
+    assertThat(tree.size()).isEqualTo(0);
 
     tree.add("Hello World!");
-    assertEquals(tree.size(), 1);
+    assertThat(tree.size()).isEqualTo(1);
   }
 
   @Test
@@ -117,29 +117,29 @@ public class BinarySearchTreeTest {
     //  A
 
     // No tree
-    assertEquals(tree.height(), 0);
+    assertThat(tree.height()).isEqualTo(0);
 
     // Layer One
     tree.add("M");
-    assertEquals(tree.height(), 1);
+    assertThat(tree.height()).isEqualTo(1);
 
     // Layer Two
     tree.add("J");
-    assertEquals(tree.height(), 2);
+    assertThat(tree.height()).isEqualTo(2);
     tree.add("S");
-    assertEquals(tree.height(), 2);
+    assertThat(tree.height()).isEqualTo(2);
 
     // Layer Three
     tree.add("B");
-    assertEquals(tree.height(), 3);
+    assertThat(tree.height()).isEqualTo(3);
     tree.add("N");
-    assertEquals(tree.height(), 3);
+    assertThat(tree.height()).isEqualTo(3);
     tree.add("Z");
-    assertEquals(tree.height(), 3);
+    assertThat(tree.height()).isEqualTo(3);
 
     // Layer 4
     tree.add("A");
-    assertEquals(tree.height(), 4);
+    assertThat(tree.height()).isEqualTo(4);
   }
 
   @Test
@@ -147,13 +147,13 @@ public class BinarySearchTreeTest {
 
     // Add element which does not yet exist
     BinarySearchTree<Character> tree = new BinarySearchTree<>();
-    assertTrue(tree.add('A'));
+    assertThat(tree.add('A')).isTrue();
 
     // Add duplicate element
-    assertFalse(tree.add('A'));
+    assertThat(tree.add('A')).isFalse();
 
     // Add a second element which is not a duplicate
-    assertTrue(tree.add('B'));
+    assertThat(tree.add('B')).isTrue();
   }
 
   @Test
@@ -162,21 +162,21 @@ public class BinarySearchTreeTest {
     // Try removing an element which doesn't exist
     BinarySearchTree<Character> tree = new BinarySearchTree<>();
     tree.add('A');
-    assertEquals(tree.size(), 1);
-    assertFalse(tree.remove('B'));
-    assertEquals(tree.size(), 1);
+    assertThat(tree.size()).isEqualTo(1);
+    assertThat(tree.remove('B')).isFalse();
+    assertThat(tree.size()).isEqualTo(1);
 
     // Try removing an element which does exist
     tree.add('B');
-    assertEquals(tree.size(), 2);
-    assertTrue(tree.remove('B'));
-    assertEquals(tree.size(), 1);
-    assertEquals(tree.height(), 1);
+    assertThat(tree.size()).isEqualTo(2);
+    assertThat(tree.remove('B')).isTrue();
+    assertThat(tree.size()).isEqualTo(1);
+    assertThat(tree.height()).isEqualTo(1);
 
     // Try removing the root
-    assertTrue(tree.remove('A'));
-    assertEquals(tree.size(), 0);
-    assertEquals(tree.height(), 0);
+    assertThat(tree.remove('A')).isTrue();
+    assertThat(tree.size()).isEqualTo(0);
+    assertThat(tree.height()).isEqualTo(0);
   }
 
   @Test
@@ -190,16 +190,16 @@ public class BinarySearchTreeTest {
     tree.add('C');
 
     // Try looking for an element which doesn't exist
-    assertFalse(tree.contains('D'));
+    assertThat(tree.contains('D')).isFalse();
 
     // Try looking for an element which exists in the root
-    assertTrue(tree.contains('B'));
+    assertThat(tree.contains('B')).isTrue();
 
     // Try looking for an element which exists as the left child of the root
-    assertTrue(tree.contains('A'));
+    assertThat(tree.contains('A')).isTrue();
 
     // Try looking for an element which exists as the right child of the root
-    assertTrue(tree.contains('C'));
+    assertThat(tree.contains('C')).isTrue();
   }
 
   @Test(expected = ConcurrentModificationException.class)
@@ -354,12 +354,12 @@ public class BinarySearchTreeTest {
 
         Integer value = lst.get(j);
 
-        assertTrue(tree.remove(value));
-        assertFalse(tree.contains(value));
-        assertEquals(tree.size(), size - j - 1);
+        assertThat(tree.remove(value)).isTrue();
+        assertThat(tree.contains(value)).isFalse();
+        assertThat(tree.size()).isEqualTo(size - j - 1);
       }
 
-      assertTrue(tree.isEmpty());
+      assertThat(tree.isEmpty()).isTrue();
     }
   }
 
@@ -418,7 +418,7 @@ public class BinarySearchTreeTest {
 
     for (int i = 0; i < LOOPS; i++) {
       List<Integer> input = genRandList(i);
-      assertTrue(validateTreeTraversal(TreeTraversalOrder.PRE_ORDER, input));
+      assertThat(validateTreeTraversal(TreeTraversalOrder.PRE_ORDER, input)).isTrue();
     }
   }
 
@@ -427,7 +427,7 @@ public class BinarySearchTreeTest {
 
     for (int i = 0; i < LOOPS; i++) {
       List<Integer> input = genRandList(i);
-      assertTrue(validateTreeTraversal(TreeTraversalOrder.IN_ORDER, input));
+      assertThat(validateTreeTraversal(TreeTraversalOrder.IN_ORDER, input)).isTrue();
     }
   }
 
@@ -436,7 +436,7 @@ public class BinarySearchTreeTest {
 
     for (int i = 0; i < LOOPS; i++) {
       List<Integer> input = genRandList(i);
-      assertTrue(validateTreeTraversal(TreeTraversalOrder.POST_ORDER, input));
+      assertThat(validateTreeTraversal(TreeTraversalOrder.POST_ORDER, input)).isTrue();
     }
   }
 
@@ -445,7 +445,7 @@ public class BinarySearchTreeTest {
 
     for (int i = 0; i < LOOPS; i++) {
       List<Integer> input = genRandList(i);
-      assertTrue(validateTreeTraversal(TreeTraversalOrder.LEVEL_ORDER, input));
+      assertThat(validateTreeTraversal(TreeTraversalOrder.LEVEL_ORDER, input)).isTrue();
     }
   }
 }

--- a/src/test/java/com/williamfiset/algorithms/datastructures/binarysearchtree/SplayTreeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/binarysearchtree/SplayTreeTest.java
@@ -1,27 +1,27 @@
 package com.williamfiset.algorithms.datastructures.binarysearchtree;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static com.google.common.truth.Truth.assertThat;
 
 import com.williamfiset.algorithms.datastructures.utils.TestUtils;
 import java.util.*;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
-class SplayTreeTest {
+public class SplayTreeTest {
 
   public static final int MAX = Integer.MAX_VALUE / 4, MIN = Integer.MIN_VALUE / 4;
 
   @Test
-  void getRoot() {
+  public void getRoot() {
     SplayTree<Integer> splayTree = new SplayTree<>();
     List<Integer> data = TestUtils.randomIntegerList(100, MIN, MAX);
     for (int i : data) {
       splayTree.insert(i);
-      assertEquals(i, splayTree.getRoot().getData());
+      assertThat(splayTree.getRoot().getData()).isEqualTo(i);
     }
   }
 
   @Test
-  void splayInsertDeleteSearch() {
+  public void splayInsertDeleteSearch() {
     SplayTree<Integer> splayTree = new SplayTree<>();
     List<Integer> data =
         TestUtils.randomUniformUniqueIntegerList(
@@ -29,61 +29,61 @@ class SplayTreeTest {
     // should assertNull
     for (int i : data) {
       splayTree.insert(i);
-      assertEquals(i, splayTree.getRoot().getData());
+      assertThat(splayTree.getRoot().getData()).isEqualTo(i);
     }
     for (int i : data) {
-      assertNotNull(splayTree.search(i));
+      assertThat(splayTree.search(i)).isNotNull();
     }
     for (int i : data) {
       splayTree.delete(i);
-      assertNull(splayTree.search(i));
+      assertThat(splayTree.search(i)).isNull();
     }
   }
 
   @Test
-  void insertSearch() {
+  public void insertSearch() {
     SplayTree<Integer> splayTree = new SplayTree<>();
     List<Integer> data = TestUtils.randomIntegerList(100, MIN, MAX);
     for (int i : data) {
       splayTree.insert(i);
-      assertEquals(i, splayTree.getRoot().getData());
+      assertThat(splayTree.getRoot().getData()).isEqualTo(i);
     }
   }
 
   @Test
-  void findMax() {
+  public void findMax() {
     SplayTree<Integer> splayTree = new SplayTree<>();
     List<Integer> data = TestUtils.sortedIntegerList(-50, 50);
     for (int i : data) {
       splayTree.insert(i);
-      assertEquals(i, splayTree.findMax(splayTree.getRoot()));
+      assertThat(splayTree.findMax(splayTree.getRoot())).isEqualTo(i);
     }
   }
 
   /** Comparison With Built In Priority Queue* */
   @Test
-  void splayTreePriorityQueueConsistencyTest() {
+  public void splayTreePriorityQueueConsistencyTest() {
     SplayTree<Integer> splayTree = new SplayTree<>();
     List<Integer> data = TestUtils.randomUniformUniqueIntegerList(100);
     Queue<Integer> pq = new PriorityQueue<>(100, Collections.reverseOrder());
 
     // insertion
     for (int i : data) {
-      assertEquals(pq.add(i), splayTree.insert(i) != null);
+      assertThat(pq.add(i)).isEqualTo(splayTree.insert(i) != null);
     }
     // searching
     for (int i : data) {
-      assertEquals(splayTree.search(i).getData().equals(i), pq.contains(i));
+      assertThat(splayTree.search(i).getData().equals(i)).isEqualTo(pq.contains(i));
     }
     // findMax & delete
     while (!pq.isEmpty()) {
       Integer splayTreeMax = splayTree.findMax();
-      assertEquals(pq.peek(), splayTreeMax);
+      assertThat(pq.peek()).isEqualTo(splayTreeMax);
 
       splayTree.delete(splayTreeMax);
-      assertNull(splayTree.search(splayTreeMax));
+      assertThat(splayTree.search(splayTreeMax)).isNull();
       pq.remove(splayTreeMax);
-      assertFalse(pq.contains(splayTreeMax));
+      assertThat(pq.contains(splayTreeMax)).isFalse();
     }
   }
 }

--- a/src/test/java/com/williamfiset/algorithms/datastructures/bloomfilter/BloomFilterTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/bloomfilter/BloomFilterTest.java
@@ -1,6 +1,6 @@
 package com.williamfiset.algorithms.datastructures.bloomfilter;
 
-import static org.junit.Assert.*;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.security.SecureRandom;
 import java.util.HashSet;
@@ -33,7 +33,7 @@ public class BloomFilterTest {
     for (int i = 0; i < s.length(); i++) {
       for (int j = i + 1; j < s.length(); j++) {
         String sub = s.substring(i, j + 1);
-        assertTrue(set.contains(sub));
+        assertThat(set.contains(sub)).isTrue();
       }
     }
   }
@@ -67,7 +67,7 @@ public class BloomFilterTest {
 
     // The probablity of a collision should be really high
     // because we're using small prime numbers
-    assertTrue(collisionHappened);
+    assertThat(collisionHappened).isTrue();
   }
 
   @Test
@@ -86,7 +86,7 @@ public class BloomFilterTest {
           set.add(randStr);
         }
 
-        for (String s : javaset) assertTrue(set.contains(s));
+        for (String s : javaset) assertThat(set.contains(s)).isTrue();;
 
         // Check that strings that aren't in the string set actually aren't
         // in the set, the probablity should be low enough that a false positive
@@ -94,7 +94,7 @@ public class BloomFilterTest {
         for (int l = 0; l < 100; l++) {
           String randStr = randomString(sz);
           if (!randStr.contains(randStr)) {
-            assertFalse(set.contains(randStr));
+            assertThat(set.contains(randStr)).isFalse();;
           }
         }
       }

--- a/src/test/java/com/williamfiset/algorithms/datastructures/bloomfilter/BloomFilterTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/bloomfilter/BloomFilterTest.java
@@ -86,7 +86,8 @@ public class BloomFilterTest {
           set.add(randStr);
         }
 
-        for (String s : javaset) assertThat(set.contains(s)).isTrue();;
+        for (String s : javaset) assertThat(set.contains(s)).isTrue();
+        ;
 
         // Check that strings that aren't in the string set actually aren't
         // in the set, the probablity should be low enough that a false positive
@@ -94,7 +95,8 @@ public class BloomFilterTest {
         for (int l = 0; l < 100; l++) {
           String randStr = randomString(sz);
           if (!randStr.contains(randStr)) {
-            assertThat(set.contains(randStr)).isFalse();;
+            assertThat(set.contains(randStr)).isFalse();
+            ;
           }
         }
       }

--- a/src/test/java/com/williamfiset/algorithms/datastructures/bloomfilter/BloomFilterTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/bloomfilter/BloomFilterTest.java
@@ -87,7 +87,6 @@ public class BloomFilterTest {
         }
 
         for (String s : javaset) assertThat(set.contains(s)).isTrue();
-        ;
 
         // Check that strings that aren't in the string set actually aren't
         // in the set, the probablity should be low enough that a false positive
@@ -96,7 +95,6 @@ public class BloomFilterTest {
           String randStr = randomString(sz);
           if (!randStr.contains(randStr)) {
             assertThat(set.contains(randStr)).isFalse();
-            ;
           }
         }
       }

--- a/src/test/java/com/williamfiset/algorithms/datastructures/dynamicarray/DynamicArrayTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/dynamicarray/DynamicArrayTest.java
@@ -1,8 +1,6 @@
 package com.williamfiset.algorithms.datastructures.dynamicarray;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static com.google.common.truth.Truth.assertThat;
 
 import org.junit.Test;
 
@@ -11,7 +9,7 @@ public class DynamicArrayTest {
   @Test
   public void testEmptyList() {
     DynamicArray<Integer> list = new DynamicArray<>();
-    assertTrue(list.isEmpty());
+    assertThat(list.isEmpty()).isTrue();;
   }
 
   @Test(expected = Exception.class)
@@ -100,28 +98,28 @@ public class DynamicArrayTest {
     for (String s : strs) list.add(s);
 
     boolean ret = list.remove("c");
-    assertTrue(ret);
+    assertThat(ret).isTrue();;
 
     ret = list.remove("c");
-    assertFalse(ret);
+    assertThat(ret).isFalse();;
 
     ret = list.remove("h");
-    assertTrue(ret);
+    assertThat(ret).isTrue();;
 
     ret = list.remove(null);
-    assertTrue(ret);
+    assertThat(ret).isTrue();;
 
     ret = list.remove("a");
-    assertTrue(ret);
+    assertThat(ret).isTrue();;
 
     ret = list.remove("a");
-    assertFalse(ret);
+    assertThat(ret).isFalse();;
 
     ret = list.remove("h");
-    assertFalse(ret);
+    assertThat(ret).isFalse();;
 
     ret = list.remove(null);
-    assertFalse(ret);
+    assertThat(ret).isFalse();;
   }
 
   @Test
@@ -131,15 +129,15 @@ public class DynamicArrayTest {
     String[] strs = {"a", "b", "c", "d"};
     for (String s : strs) list.add(s);
 
-    assertTrue(list.remove("a"));
-    assertTrue(list.remove("b"));
-    assertTrue(list.remove("c"));
-    assertTrue(list.remove("d"));
+    assertThat(list.remove("a")).isTrue();;
+    assertThat(list.remove("b")).isTrue();;
+    assertThat(list.remove("c")).isTrue();;
+    assertThat(list.remove("d")).isTrue();;
 
-    assertFalse(list.remove("a"));
-    assertFalse(list.remove("b"));
-    assertFalse(list.remove("c"));
-    assertFalse(list.remove("d"));
+    assertThat(list.remove("a")).isFalse();;
+    assertThat(list.remove("b")).isFalse();;
+    assertThat(list.remove("c")).isFalse();;
+    assertThat(list.remove("d")).isFalse();;
   }
 
   @Test
@@ -147,7 +145,7 @@ public class DynamicArrayTest {
     DynamicArray<String> list = new DynamicArray<>();
     String[] strs = {"a", "b", null, "d"};
     for (String s : strs) list.add(s);
-    assertTrue(list.indexOf(null) == 2);
+    assertThat(list.indexOf(null)).isEqualTo(2);
   }
 
   @Test
@@ -159,7 +157,7 @@ public class DynamicArrayTest {
 
     for (int i = 0; i < elems.length; i++) list.add(elems[i]);
 
-    for (int i = 0; i < elems.length; i++) assertEquals(list.get(i).intValue(), elems[i]);
+    for (int i = 0; i < elems.length; i++) assertThat(list.get(i).intValue()).isEqualTo(elems[i]);
   }
 
   @Test
@@ -169,19 +167,19 @@ public class DynamicArrayTest {
 
     for (int i = 0; i < 55; i++) list.add(44L);
     for (int i = 0; i < 55; i++) list.remove(44L);
-    assertTrue(list.isEmpty());
+    assertThat(list.isEmpty()).isTrue();
 
     for (int i = 0; i < 55; i++) list.add(44L);
     for (int i = 0; i < 55; i++) list.removeAt(0);
-    assertTrue(list.isEmpty());
+    assertThat(list.isEmpty()).isTrue();
 
     for (int i = 0; i < 155; i++) list.add(44L);
     for (int i = 0; i < 155; i++) list.remove(44L);
-    assertTrue(list.isEmpty());
+    assertThat(list.isEmpty()).isTrue();
 
     for (int i = 0; i < 155; i++) list.add(44L);
     for (int i = 0; i < 155; i++) list.removeAt(0);
-    assertTrue(list.isEmpty());
+    assertThat(list.isEmpty()).isTrue();
   }
 
   @Test
@@ -192,21 +190,21 @@ public class DynamicArrayTest {
     for (int i = 0; i < 55; i++) list.add(44L);
     for (int i = 0; i < 55; i++) list.set(i, 33L);
     for (int i = 0; i < 55; i++) list.remove(33L);
-    assertTrue(list.isEmpty());
+    assertThat(list.isEmpty()).isTrue();
 
     for (int i = 0; i < 55; i++) list.add(44L);
     for (int i = 0; i < 55; i++) list.set(i, 33L);
     for (int i = 0; i < 55; i++) list.removeAt(0);
-    assertTrue(list.isEmpty());
+    assertThat(list.isEmpty()).isTrue();
 
     for (int i = 0; i < 155; i++) list.add(44L);
     for (int i = 0; i < 155; i++) list.set(i, 33L);
     for (int i = 0; i < 155; i++) list.remove(33L);
-    assertTrue(list.isEmpty());
+    assertThat(list.isEmpty()).isTrue();
 
     for (int i = 0; i < 155; i++) list.add(44L);
     for (int i = 0; i < 155; i++) list.removeAt(0);
-    assertTrue(list.isEmpty());
+    assertThat(list.isEmpty()).isTrue();
   }
 
   @Test
@@ -217,7 +215,7 @@ public class DynamicArrayTest {
     Integer[] elems = {-76, 45, 66, 3, null, 54, 33};
     for (int i = 0, sz = 1; i < elems.length; i++, sz++) {
       list.add(elems[i]);
-      assertEquals(list.size(), sz);
+      assertThat(list.size()).isEqualTo(sz);
     }
   }
 }

--- a/src/test/java/com/williamfiset/algorithms/datastructures/dynamicarray/DynamicArrayTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/dynamicarray/DynamicArrayTest.java
@@ -9,7 +9,8 @@ public class DynamicArrayTest {
   @Test
   public void testEmptyList() {
     DynamicArray<Integer> list = new DynamicArray<>();
-    assertThat(list.isEmpty()).isTrue();;
+    assertThat(list.isEmpty()).isTrue();
+    ;
   }
 
   @Test(expected = Exception.class)
@@ -98,28 +99,36 @@ public class DynamicArrayTest {
     for (String s : strs) list.add(s);
 
     boolean ret = list.remove("c");
-    assertThat(ret).isTrue();;
+    assertThat(ret).isTrue();
+    ;
 
     ret = list.remove("c");
-    assertThat(ret).isFalse();;
+    assertThat(ret).isFalse();
+    ;
 
     ret = list.remove("h");
-    assertThat(ret).isTrue();;
+    assertThat(ret).isTrue();
+    ;
 
     ret = list.remove(null);
-    assertThat(ret).isTrue();;
+    assertThat(ret).isTrue();
+    ;
 
     ret = list.remove("a");
-    assertThat(ret).isTrue();;
+    assertThat(ret).isTrue();
+    ;
 
     ret = list.remove("a");
-    assertThat(ret).isFalse();;
+    assertThat(ret).isFalse();
+    ;
 
     ret = list.remove("h");
-    assertThat(ret).isFalse();;
+    assertThat(ret).isFalse();
+    ;
 
     ret = list.remove(null);
-    assertThat(ret).isFalse();;
+    assertThat(ret).isFalse();
+    ;
   }
 
   @Test
@@ -129,15 +138,23 @@ public class DynamicArrayTest {
     String[] strs = {"a", "b", "c", "d"};
     for (String s : strs) list.add(s);
 
-    assertThat(list.remove("a")).isTrue();;
-    assertThat(list.remove("b")).isTrue();;
-    assertThat(list.remove("c")).isTrue();;
-    assertThat(list.remove("d")).isTrue();;
+    assertThat(list.remove("a")).isTrue();
+    ;
+    assertThat(list.remove("b")).isTrue();
+    ;
+    assertThat(list.remove("c")).isTrue();
+    ;
+    assertThat(list.remove("d")).isTrue();
+    ;
 
-    assertThat(list.remove("a")).isFalse();;
-    assertThat(list.remove("b")).isFalse();;
-    assertThat(list.remove("c")).isFalse();;
-    assertThat(list.remove("d")).isFalse();;
+    assertThat(list.remove("a")).isFalse();
+    ;
+    assertThat(list.remove("b")).isFalse();
+    ;
+    assertThat(list.remove("c")).isFalse();
+    ;
+    assertThat(list.remove("d")).isFalse();
+    ;
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/dynamicarray/DynamicArrayTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/dynamicarray/DynamicArrayTest.java
@@ -10,7 +10,6 @@ public class DynamicArrayTest {
   public void testEmptyList() {
     DynamicArray<Integer> list = new DynamicArray<>();
     assertThat(list.isEmpty()).isTrue();
-    ;
   }
 
   @Test(expected = Exception.class)
@@ -100,35 +99,27 @@ public class DynamicArrayTest {
 
     boolean ret = list.remove("c");
     assertThat(ret).isTrue();
-    ;
 
     ret = list.remove("c");
     assertThat(ret).isFalse();
-    ;
 
     ret = list.remove("h");
     assertThat(ret).isTrue();
-    ;
 
     ret = list.remove(null);
     assertThat(ret).isTrue();
-    ;
 
     ret = list.remove("a");
     assertThat(ret).isTrue();
-    ;
 
     ret = list.remove("a");
     assertThat(ret).isFalse();
-    ;
 
     ret = list.remove("h");
     assertThat(ret).isFalse();
-    ;
 
     ret = list.remove(null);
     assertThat(ret).isFalse();
-    ;
   }
 
   @Test
@@ -139,22 +130,14 @@ public class DynamicArrayTest {
     for (String s : strs) list.add(s);
 
     assertThat(list.remove("a")).isTrue();
-    ;
     assertThat(list.remove("b")).isTrue();
-    ;
     assertThat(list.remove("c")).isTrue();
-    ;
     assertThat(list.remove("d")).isTrue();
-    ;
 
     assertThat(list.remove("a")).isFalse();
-    ;
     assertThat(list.remove("b")).isFalse();
-    ;
     assertThat(list.remove("c")).isFalse();
-    ;
     assertThat(list.remove("d")).isFalse();
-    ;
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/fenwicktree/FenwickTreeRangeQueryPointUpdateTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/fenwicktree/FenwickTreeRangeQueryPointUpdateTest.java
@@ -1,6 +1,6 @@
 package com.williamfiset.algorithms.datastructures.fenwicktree;
 
-import static org.junit.Assert.assertEquals;
+import static com.google.common.truth.Truth.assertThat;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -27,24 +27,24 @@ public class FenwickTreeRangeQueryPointUpdateTest {
     long[] ar = {UNUSED_VAL, 1, 2, 3, 4, 5, 6};
     FenwickTreeRangeQueryPointUpdate ft = new FenwickTreeRangeQueryPointUpdate(ar);
 
-    assertEquals(21, ft.sum(1, 6));
-    assertEquals(15, ft.sum(1, 5));
-    assertEquals(10, ft.sum(1, 4));
-    assertEquals(6, ft.sum(1, 3));
-    assertEquals(3, ft.sum(1, 2));
-    assertEquals(1, ft.sum(1, 1));
+    assertThat(ft.sum(1, 6)).isEqualTo(21);;
+    assertThat(ft.sum(1, 5)).isEqualTo(15);;
+    assertThat(ft.sum(1, 4)).isEqualTo(10);;
+    assertThat(ft.sum(1, 3)).isEqualTo(6);;
+    assertThat(ft.sum(1, 2)).isEqualTo(3);;
+    assertThat(ft.sum(1, 1)).isEqualTo(1);;
     // assertEquals(  0, ft.sum(1, 0) );
 
-    assertEquals(7, ft.sum(3, 4));
-    assertEquals(20, ft.sum(2, 6));
-    assertEquals(9, ft.sum(4, 5));
+    assertThat(ft.sum(3, 4)).isEqualTo(7);;
+    assertThat(ft.sum(2, 6)).isEqualTo(20);;
+    assertThat(ft.sum(4, 5)).isEqualTo(9);;
 
-    assertEquals(6, ft.sum(6, 6));
-    assertEquals(5, ft.sum(5, 5));
-    assertEquals(4, ft.sum(4, 4));
-    assertEquals(3, ft.sum(3, 3));
-    assertEquals(2, ft.sum(2, 2));
-    assertEquals(1, ft.sum(1, 1));
+    assertThat(ft.sum(6, 6)).isEqualTo(6);;
+    assertThat(ft.sum(5, 5)).isEqualTo(5);;
+    assertThat(ft.sum(4, 4)).isEqualTo(4);;
+    assertThat(ft.sum(3, 3)).isEqualTo(3);;
+    assertThat(ft.sum(2, 2)).isEqualTo(2);;
+    assertThat(ft.sum(1, 1)).isEqualTo(1);;
   }
 
   @Test
@@ -54,19 +54,19 @@ public class FenwickTreeRangeQueryPointUpdateTest {
     long[] ar = {UNUSED_VAL, -1, -2, -3, -4, -5, -6};
     FenwickTreeRangeQueryPointUpdate ft = new FenwickTreeRangeQueryPointUpdate(ar);
 
-    assertEquals(-21, ft.sum(1, 6));
-    assertEquals(-15, ft.sum(1, 5));
-    assertEquals(-10, ft.sum(1, 4));
-    assertEquals(-6, ft.sum(1, 3));
-    assertEquals(-3, ft.sum(1, 2));
-    assertEquals(-1, ft.sum(1, 1));
+    assertThat(ft.sum(1, 6)).isEqualTo(-21);
+    assertThat(ft.sum(1, 5)).isEqualTo(-15);
+    assertThat(ft.sum(1, 4)).isEqualTo(-10);
+    assertThat(ft.sum(1, 3)).isEqualTo(-6);
+    assertThat(ft.sum(1, 2)).isEqualTo(-3);
+    assertThat(ft.sum(1, 1)).isEqualTo(-1);
 
-    assertEquals(-6, ft.sum(6, 6));
-    assertEquals(-5, ft.sum(5, 5));
-    assertEquals(-4, ft.sum(4, 4));
-    assertEquals(-3, ft.sum(3, 3));
-    assertEquals(-2, ft.sum(2, 2));
-    assertEquals(-1, ft.sum(1, 1));
+    assertThat(ft.sum(6, 6)).isEqualTo(-6);
+    assertThat(ft.sum(5, 5)).isEqualTo(-5);
+    assertThat(ft.sum(4, 4)).isEqualTo(-4);
+    assertThat(ft.sum(3, 3)).isEqualTo(-3);
+    assertThat(ft.sum(2, 2)).isEqualTo(-2);
+    assertThat(ft.sum(1, 1)).isEqualTo(-1);
   }
 
   @Test
@@ -77,14 +77,14 @@ public class FenwickTreeRangeQueryPointUpdateTest {
     FenwickTreeRangeQueryPointUpdate ft = new FenwickTreeRangeQueryPointUpdate(ar);
 
     for (int i = 0; i < LOOPS; i++) {
-      assertEquals(-76871, ft.sum(1, 1));
-      assertEquals(-76871, ft.sum(1, 1));
-      assertEquals(-241661, ft.sum(1, 2));
-      assertEquals(-241661, ft.sum(1, 2));
-      assertEquals(-241661, ft.sum(1, 2));
-      assertEquals(-164790, ft.sum(2, 2));
-      assertEquals(-164790, ft.sum(2, 2));
-      assertEquals(-164790, ft.sum(2, 2));
+      assertThat(ft.sum(1, 1)).isEqualTo(-76871);
+      assertThat(ft.sum(1, 1)).isEqualTo(-76871);
+      assertThat(ft.sum(1, 2)).isEqualTo(-241661);
+      assertThat(ft.sum(1, 2)).isEqualTo(-241661);
+      assertThat(ft.sum(1, 2)).isEqualTo(-241661);
+      assertThat(ft.sum(2, 2)).isEqualTo(-164790);
+      assertThat(ft.sum(2, 2)).isEqualTo(-164790);
+      assertThat(ft.sum(2, 2)).isEqualTo(-164790);
     }
   }
 
@@ -115,7 +115,7 @@ public class FenwickTreeRangeQueryPointUpdateTest {
 
     for (int k = lo; k <= hi; k++) sum += arr[k];
 
-    assertEquals(sum, ft.sum(lo, hi));
+    assertThat(ft.sum(lo, hi)).isEqualTo(sum);
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/fenwicktree/FenwickTreeRangeQueryPointUpdateTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/fenwicktree/FenwickTreeRangeQueryPointUpdateTest.java
@@ -28,38 +28,22 @@ public class FenwickTreeRangeQueryPointUpdateTest {
     FenwickTreeRangeQueryPointUpdate ft = new FenwickTreeRangeQueryPointUpdate(ar);
 
     assertThat(ft.sum(1, 6)).isEqualTo(21);
-    ;
     assertThat(ft.sum(1, 5)).isEqualTo(15);
-    ;
     assertThat(ft.sum(1, 4)).isEqualTo(10);
-    ;
     assertThat(ft.sum(1, 3)).isEqualTo(6);
-    ;
     assertThat(ft.sum(1, 2)).isEqualTo(3);
-    ;
     assertThat(ft.sum(1, 1)).isEqualTo(1);
-    ;
-    // assertEquals(  0, ft.sum(1, 0) );
+    // assertThat(ft.sum(1, 0)).isEqualTo(0);
 
     assertThat(ft.sum(3, 4)).isEqualTo(7);
-    ;
     assertThat(ft.sum(2, 6)).isEqualTo(20);
-    ;
     assertThat(ft.sum(4, 5)).isEqualTo(9);
-    ;
-
     assertThat(ft.sum(6, 6)).isEqualTo(6);
-    ;
     assertThat(ft.sum(5, 5)).isEqualTo(5);
-    ;
     assertThat(ft.sum(4, 4)).isEqualTo(4);
-    ;
     assertThat(ft.sum(3, 3)).isEqualTo(3);
-    ;
     assertThat(ft.sum(2, 2)).isEqualTo(2);
-    ;
     assertThat(ft.sum(1, 1)).isEqualTo(1);
-    ;
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/fenwicktree/FenwickTreeRangeQueryPointUpdateTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/fenwicktree/FenwickTreeRangeQueryPointUpdateTest.java
@@ -27,24 +27,39 @@ public class FenwickTreeRangeQueryPointUpdateTest {
     long[] ar = {UNUSED_VAL, 1, 2, 3, 4, 5, 6};
     FenwickTreeRangeQueryPointUpdate ft = new FenwickTreeRangeQueryPointUpdate(ar);
 
-    assertThat(ft.sum(1, 6)).isEqualTo(21);;
-    assertThat(ft.sum(1, 5)).isEqualTo(15);;
-    assertThat(ft.sum(1, 4)).isEqualTo(10);;
-    assertThat(ft.sum(1, 3)).isEqualTo(6);;
-    assertThat(ft.sum(1, 2)).isEqualTo(3);;
-    assertThat(ft.sum(1, 1)).isEqualTo(1);;
+    assertThat(ft.sum(1, 6)).isEqualTo(21);
+    ;
+    assertThat(ft.sum(1, 5)).isEqualTo(15);
+    ;
+    assertThat(ft.sum(1, 4)).isEqualTo(10);
+    ;
+    assertThat(ft.sum(1, 3)).isEqualTo(6);
+    ;
+    assertThat(ft.sum(1, 2)).isEqualTo(3);
+    ;
+    assertThat(ft.sum(1, 1)).isEqualTo(1);
+    ;
     // assertEquals(  0, ft.sum(1, 0) );
 
-    assertThat(ft.sum(3, 4)).isEqualTo(7);;
-    assertThat(ft.sum(2, 6)).isEqualTo(20);;
-    assertThat(ft.sum(4, 5)).isEqualTo(9);;
+    assertThat(ft.sum(3, 4)).isEqualTo(7);
+    ;
+    assertThat(ft.sum(2, 6)).isEqualTo(20);
+    ;
+    assertThat(ft.sum(4, 5)).isEqualTo(9);
+    ;
 
-    assertThat(ft.sum(6, 6)).isEqualTo(6);;
-    assertThat(ft.sum(5, 5)).isEqualTo(5);;
-    assertThat(ft.sum(4, 4)).isEqualTo(4);;
-    assertThat(ft.sum(3, 3)).isEqualTo(3);;
-    assertThat(ft.sum(2, 2)).isEqualTo(2);;
-    assertThat(ft.sum(1, 1)).isEqualTo(1);;
+    assertThat(ft.sum(6, 6)).isEqualTo(6);
+    ;
+    assertThat(ft.sum(5, 5)).isEqualTo(5);
+    ;
+    assertThat(ft.sum(4, 4)).isEqualTo(4);
+    ;
+    assertThat(ft.sum(3, 3)).isEqualTo(3);
+    ;
+    assertThat(ft.sum(2, 2)).isEqualTo(2);
+    ;
+    assertThat(ft.sum(1, 1)).isEqualTo(1);
+    ;
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/fenwicktree/FenwickTreeRangeUpdatePointQueryTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/fenwicktree/FenwickTreeRangeUpdatePointQueryTest.java
@@ -1,6 +1,6 @@
 package com.williamfiset.algorithms.datastructures.fenwicktree;
 
-import static org.junit.Assert.*;
+import static com.google.common.truth.Truth.assertThat;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -47,11 +47,11 @@ public class FenwickTreeRangeUpdatePointQueryTest {
     long[] values = {UNUSED_VAL, -1, -1, -1, -1, -1};
     FenwickTreeRangeUpdatePointQuery ft = new FenwickTreeRangeUpdatePointQuery(values);
     ft.updateRange(2, 4, 10);
-    assertEquals(-1, ft.get(1));
-    assertEquals(9, ft.get(2));
-    assertEquals(9, ft.get(3));
-    assertEquals(9, ft.get(4));
-    assertEquals(-1, ft.get(5));
+    assertThat(ft.get(1)).isEqualTo(-1);;
+    assertThat(ft.get(2)).isEqualTo(9);;
+    assertThat(ft.get(3)).isEqualTo(9);;
+    assertThat(ft.get(4)).isEqualTo(9);;
+    assertThat(ft.get(5)).isEqualTo(-1);;
   }
 
   @Test
@@ -60,11 +60,11 @@ public class FenwickTreeRangeUpdatePointQueryTest {
     long[] values = {UNUSED_VAL, 2, 3, 4, 5, 6};
     FenwickTreeRangeUpdatePointQuery ft = new FenwickTreeRangeUpdatePointQuery(values);
     ft.updateRange(2, 4, 10);
-    assertEquals(2, ft.get(1));
-    assertEquals(13, ft.get(2));
-    assertEquals(14, ft.get(3));
-    assertEquals(15, ft.get(4));
-    assertEquals(6, ft.get(5));
+    assertThat(ft.get(1)).isEqualTo(2);;
+    assertThat(ft.get(2)).isEqualTo(13);;
+    assertThat(ft.get(3)).isEqualTo(14);;
+    assertThat(ft.get(4)).isEqualTo(15);;
+    assertThat(ft.get(5)).isEqualTo(6);;
   }
 
   @Test
@@ -73,11 +73,11 @@ public class FenwickTreeRangeUpdatePointQueryTest {
     long[] values = {UNUSED_VAL, 2, -3, -4, 5, 6};
     FenwickTreeRangeUpdatePointQuery ft = new FenwickTreeRangeUpdatePointQuery(values);
     ft.updateRange(2, 4, 10);
-    assertEquals(2, ft.get(1));
-    assertEquals(7, ft.get(2));
-    assertEquals(6, ft.get(3));
-    assertEquals(15, ft.get(4));
-    assertEquals(6, ft.get(5));
+    assertThat(ft.get(1)).isEqualTo(2);
+    assertThat(ft.get(2)).isEqualTo(7);
+    assertThat(ft.get(3)).isEqualTo(6);
+    assertThat(ft.get(4)).isEqualTo(15);
+    assertThat(ft.get(5)).isEqualTo(6);
   }
 
   @Test
@@ -92,7 +92,7 @@ public class FenwickTreeRangeUpdatePointQueryTest {
     int delta = 10;
 
     for (int loop = 0; loop < TEST_SZ; loop++) {
-      for (int i = 1; i < n; i++) assertEquals(sum, ft.get(i));
+      for (int i = 1; i < n; i++) assertThat(ft.get(i)).isEqualTo(sum);
       ft.updateRange(1, n - 1, delta);
       sum += delta;
     }
@@ -111,7 +111,7 @@ public class FenwickTreeRangeUpdatePointQueryTest {
 
     for (int loop = 0; loop < TEST_SZ; loop++) {
 
-      for (int i = 1; i < n; i++) assertEquals(mockedFt.get(i), ft.get(i));
+      for (int i = 1; i < n; i++) assertThat(ft.get(i)).isEqualTo(mockedFt.get(i));
 
       long delta = randValue();
       int lo = lowBound(n);

--- a/src/test/java/com/williamfiset/algorithms/datastructures/fenwicktree/FenwickTreeRangeUpdatePointQueryTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/fenwicktree/FenwickTreeRangeUpdatePointQueryTest.java
@@ -48,15 +48,10 @@ public class FenwickTreeRangeUpdatePointQueryTest {
     FenwickTreeRangeUpdatePointQuery ft = new FenwickTreeRangeUpdatePointQuery(values);
     ft.updateRange(2, 4, 10);
     assertThat(ft.get(1)).isEqualTo(-1);
-    ;
     assertThat(ft.get(2)).isEqualTo(9);
-    ;
     assertThat(ft.get(3)).isEqualTo(9);
-    ;
     assertThat(ft.get(4)).isEqualTo(9);
-    ;
     assertThat(ft.get(5)).isEqualTo(-1);
-    ;
   }
 
   @Test
@@ -66,15 +61,10 @@ public class FenwickTreeRangeUpdatePointQueryTest {
     FenwickTreeRangeUpdatePointQuery ft = new FenwickTreeRangeUpdatePointQuery(values);
     ft.updateRange(2, 4, 10);
     assertThat(ft.get(1)).isEqualTo(2);
-    ;
     assertThat(ft.get(2)).isEqualTo(13);
-    ;
     assertThat(ft.get(3)).isEqualTo(14);
-    ;
     assertThat(ft.get(4)).isEqualTo(15);
-    ;
     assertThat(ft.get(5)).isEqualTo(6);
-    ;
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/fenwicktree/FenwickTreeRangeUpdatePointQueryTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/fenwicktree/FenwickTreeRangeUpdatePointQueryTest.java
@@ -47,11 +47,16 @@ public class FenwickTreeRangeUpdatePointQueryTest {
     long[] values = {UNUSED_VAL, -1, -1, -1, -1, -1};
     FenwickTreeRangeUpdatePointQuery ft = new FenwickTreeRangeUpdatePointQuery(values);
     ft.updateRange(2, 4, 10);
-    assertThat(ft.get(1)).isEqualTo(-1);;
-    assertThat(ft.get(2)).isEqualTo(9);;
-    assertThat(ft.get(3)).isEqualTo(9);;
-    assertThat(ft.get(4)).isEqualTo(9);;
-    assertThat(ft.get(5)).isEqualTo(-1);;
+    assertThat(ft.get(1)).isEqualTo(-1);
+    ;
+    assertThat(ft.get(2)).isEqualTo(9);
+    ;
+    assertThat(ft.get(3)).isEqualTo(9);
+    ;
+    assertThat(ft.get(4)).isEqualTo(9);
+    ;
+    assertThat(ft.get(5)).isEqualTo(-1);
+    ;
   }
 
   @Test
@@ -60,11 +65,16 @@ public class FenwickTreeRangeUpdatePointQueryTest {
     long[] values = {UNUSED_VAL, 2, 3, 4, 5, 6};
     FenwickTreeRangeUpdatePointQuery ft = new FenwickTreeRangeUpdatePointQuery(values);
     ft.updateRange(2, 4, 10);
-    assertThat(ft.get(1)).isEqualTo(2);;
-    assertThat(ft.get(2)).isEqualTo(13);;
-    assertThat(ft.get(3)).isEqualTo(14);;
-    assertThat(ft.get(4)).isEqualTo(15);;
-    assertThat(ft.get(5)).isEqualTo(6);;
+    assertThat(ft.get(1)).isEqualTo(2);
+    ;
+    assertThat(ft.get(2)).isEqualTo(13);
+    ;
+    assertThat(ft.get(3)).isEqualTo(14);
+    ;
+    assertThat(ft.get(4)).isEqualTo(15);
+    ;
+    assertThat(ft.get(5)).isEqualTo(6);
+    ;
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableDoubleHashingTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableDoubleHashingTest.java
@@ -1,6 +1,6 @@
 package com.williamfiset.algorithms.datastructures.hashtable;
 
-import static org.junit.Assert.*;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.util.*;
 import org.junit.*;
@@ -57,13 +57,13 @@ public class HashTableDoubleHashingTest {
     DoubleHashingTestObject on7 = new DoubleHashingTestObject(-7);
 
     map.add(o1, 1);
-    assertTrue(1 == map.get(o1));
+    assertThat(map.get(o1)).isEqualTo(1);
 
     map.add(o5, 5);
-    assertTrue(5 == map.get(o5));
+    assertThat(map.get(o5)).isEqualTo(5);
 
     map.add(on7, -7);
-    assertTrue(-7 == map.get(on7));
+    assertThat(map.get(on7)).isEqualTo(-7);
   }
 
   @Test
@@ -78,23 +78,23 @@ public class HashTableDoubleHashingTest {
 
       mmap.clear();
       jmap.clear();
-      assertTrue(mmap.isEmpty());
+      assertThat(mmap.isEmpty()).isTrue();;
 
       List<DoubleHashingTestObject> rand_nums = genRandList(MAX_SIZE);
       for (DoubleHashingTestObject key : rand_nums)
-        assertEquals(mmap.add(key, key), jmap.put(key, key));
+        assertThat(mmap.add(key, key)).isEqualTo(jmap.put(key, key));
 
       int count = 0;
       for (DoubleHashingTestObject key : mmap) {
-        assertEquals(key, mmap.get(key));
-        assertEquals(mmap.get(key), jmap.get(key));
-        assertTrue(mmap.hasKey(key));
-        assertTrue(rand_nums.contains(key));
+        assertThat(mmap.get(key)).isEqualTo(key);
+        assertThat(mmap.get(key)).isEqualTo(jmap.get(key));
+        assertThat(mmap.hasKey(key)).isTrue();;
+        assertThat(rand_nums.contains(key)).isTrue();;
         count++;
       }
 
       for (DoubleHashingTestObject key : jmap.keySet()) {
-        assertEquals(key, mmap.get(key));
+        assertThat(mmap.get(key)).isEqualTo(key);;
       }
 
       Set<DoubleHashingTestObject> set = new HashSet<>();
@@ -102,8 +102,8 @@ public class HashTableDoubleHashingTest {
 
       // System.out.println(set.size() + " " + jmap.size() + " " + count);
 
-      assertEquals(set.size(), count);
-      assertEquals(jmap.size(), count);
+      assertThat(set.size()).isEqualTo(count);
+      assertThat(jmap.size()).isEqualTo(count);
     }
   }
 
@@ -150,12 +150,12 @@ public class HashTableDoubleHashingTest {
         map.put(obj, 5);
       }
 
-      assertEquals(map.size(), keys_set.size());
+      assertThat(map.size()).isEqualTo(keys_set.size());
 
       List<DoubleHashingTestObject> keys = map.keys();
       for (DoubleHashingTestObject key : keys) map.remove(key);
 
-      assertTrue(map.isEmpty());
+      assertThat(map.isEmpty()).isTrue();
     }
   }
 
@@ -172,21 +172,21 @@ public class HashTableDoubleHashingTest {
     map.put(o11, 0);
     map.put(o12, 0);
     map.put(o13, 0);
-    assertEquals(3, map.size());
+    assertThat(map.size()).isEqualTo(3);
 
     // Add ten more
     for (int i = 1; i <= 10; i++) map.put(new DoubleHashingTestObject(i), 0);
-    assertEquals(13, map.size());
+    assertThat(map.size()).isEqualTo(13);
 
     // Remove ten
     for (int i = 1; i <= 10; i++) map.remove(new DoubleHashingTestObject(i));
-    assertEquals(3, map.size());
+    assertThat(map.size()).isEqualTo(3);
 
     // remove three
     map.remove(o11);
     map.remove(o12);
     map.remove(o13);
-    assertEquals(0, map.size());
+    assertThat(map.size()).isEqualTo(0);
   }
 
   @Test
@@ -198,7 +198,7 @@ public class HashTableDoubleHashingTest {
 
       map.clear();
       jmap.clear();
-      assertEquals(jmap.size(), map.size());
+      assertThat(jmap.size()).isEqualTo(map.size());
 
       map = new HashTableDoubleHashing<>();
 
@@ -213,17 +213,17 @@ public class HashTableDoubleHashingTest {
         DoubleHashingTestObject key = nums.get(i);
         int val = i;
 
-        if (r < probability1) assertEquals(jmap.put(key, val), map.put(key, val));
+        if (r < probability1) assertThat(jmap.put(key, val)).isEqualTo(map.put(key, val));
 
-        assertEquals(jmap.get(key), map.get(key));
-        assertEquals(jmap.containsKey(key), map.containsKey(key));
-        assertEquals(jmap.size(), map.size());
+        assertThat(jmap.get(key)).isEqualTo(map.get(key));
+        assertThat(jmap.containsKey(key)).isEqualTo(map.containsKey(key));
+        assertThat(jmap.size()).isEqualTo(map.size());
 
-        if (r > probability2) assertEquals(map.remove(key), jmap.remove(key));
+        if (r > probability2) assertThat(map.remove(key)).isEqualTo(jmap.remove(key));
 
-        assertEquals(jmap.get(key), map.get(key));
-        assertEquals(jmap.containsKey(key), map.containsKey(key));
-        assertEquals(jmap.size(), map.size());
+        assertThat(jmap.get(key)).isEqualTo(map.get(key));
+        assertThat(jmap.containsKey(key)).isEqualTo(map.containsKey(key));
+        assertThat(jmap.size()).isEqualTo(map.size());
       }
     }
   }
@@ -239,7 +239,7 @@ public class HashTableDoubleHashingTest {
 
       m.clear();
       hm.clear();
-      assertEquals(m.size(), hm.size());
+      assertThat(m.size()).isEqualTo(hm.size());
 
       int sz = randInt(1, MAX_SIZE);
       m = new HashTableDoubleHashing<>(sz);
@@ -274,8 +274,8 @@ public class HashTableDoubleHashingTest {
           l2.add(randVal);
         }
 
-        assertEquals(m.size(), hm.size());
-        assertEquals(l1, l2);
+        assertThat(m.size()).isEqualTo(hm.size());
+        assertThat(l1).isEqualTo(l2);
       }
     }
   }

--- a/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableDoubleHashingTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableDoubleHashingTest.java
@@ -79,7 +79,6 @@ public class HashTableDoubleHashingTest {
       mmap.clear();
       jmap.clear();
       assertThat(mmap.isEmpty()).isTrue();
-      ;
 
       List<DoubleHashingTestObject> rand_nums = genRandList(MAX_SIZE);
       for (DoubleHashingTestObject key : rand_nums)
@@ -90,15 +89,12 @@ public class HashTableDoubleHashingTest {
         assertThat(mmap.get(key)).isEqualTo(key);
         assertThat(mmap.get(key)).isEqualTo(jmap.get(key));
         assertThat(mmap.hasKey(key)).isTrue();
-        ;
         assertThat(rand_nums.contains(key)).isTrue();
-        ;
         count++;
       }
 
       for (DoubleHashingTestObject key : jmap.keySet()) {
         assertThat(mmap.get(key)).isEqualTo(key);
-        ;
       }
 
       Set<DoubleHashingTestObject> set = new HashSet<>();

--- a/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableDoubleHashingTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableDoubleHashingTest.java
@@ -78,7 +78,8 @@ public class HashTableDoubleHashingTest {
 
       mmap.clear();
       jmap.clear();
-      assertThat(mmap.isEmpty()).isTrue();;
+      assertThat(mmap.isEmpty()).isTrue();
+      ;
 
       List<DoubleHashingTestObject> rand_nums = genRandList(MAX_SIZE);
       for (DoubleHashingTestObject key : rand_nums)
@@ -88,13 +89,16 @@ public class HashTableDoubleHashingTest {
       for (DoubleHashingTestObject key : mmap) {
         assertThat(mmap.get(key)).isEqualTo(key);
         assertThat(mmap.get(key)).isEqualTo(jmap.get(key));
-        assertThat(mmap.hasKey(key)).isTrue();;
-        assertThat(rand_nums.contains(key)).isTrue();;
+        assertThat(mmap.hasKey(key)).isTrue();
+        ;
+        assertThat(rand_nums.contains(key)).isTrue();
+        ;
         count++;
       }
 
       for (DoubleHashingTestObject key : jmap.keySet()) {
-        assertThat(mmap.get(key)).isEqualTo(key);;
+        assertThat(mmap.get(key)).isEqualTo(key);
+        ;
       }
 
       Set<DoubleHashingTestObject> set = new HashSet<>();

--- a/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableLinearProbingTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableLinearProbingTest.java
@@ -78,7 +78,6 @@ public class HashTableLinearProbingTest {
 
     map.add(1, 5);
     assertThat(map.get(1)).isEqualTo(5);
-    ;
 
     map.add(1, -7);
     assertThat(map.get(1)).isEqualTo(-7);
@@ -94,7 +93,6 @@ public class HashTableLinearProbingTest {
       map.clear();
       map2.clear();
       assertThat(map.isEmpty()).isTrue();
-      ;
 
       map = new HashTableLinearProbing<>();
 
@@ -104,7 +102,6 @@ public class HashTableLinearProbingTest {
       int count = 0;
       for (Integer key : map) {
         assertThat(map.get(key)).isEqualTo(key);
-        ;
         assertThat(map.get(key)).isEqualTo(map2.get(key));
         assertThat(map.hasKey(key)).isTrue();
         assertThat(rand_nums.contains(key)).isTrue();
@@ -163,7 +160,6 @@ public class HashTableLinearProbingTest {
       for (Integer key : keys) map.remove(key);
 
       assertThat(map.isEmpty()).isTrue();
-      ;
     }
   }
 

--- a/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableLinearProbingTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableLinearProbingTest.java
@@ -1,6 +1,6 @@
 package com.williamfiset.algorithms.datastructures.hashtable;
 
-import static org.junit.Assert.*;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.util.*;
 import org.junit.*;
@@ -74,13 +74,13 @@ public class HashTableLinearProbingTest {
   public void testUpdatingValue() {
 
     map.add(1, 1);
-    assertTrue(1 == map.get(1));
+    assertThat(map.get(1)).isEqualTo(1);
 
     map.add(1, 5);
-    assertTrue(5 == map.get(1));
+    assertThat(map.get(1)).isEqualTo(5);;
 
     map.add(1, -7);
-    assertTrue(-7 == map.get(1));
+    assertThat(map.get(1)).isEqualTo(-7);
   }
 
   @Test
@@ -92,31 +92,31 @@ public class HashTableLinearProbingTest {
 
       map.clear();
       map2.clear();
-      assertTrue(map.isEmpty());
+      assertThat(map.isEmpty()).isTrue();;
 
       map = new HashTableLinearProbing<>();
 
       List<Integer> rand_nums = genRandList(MAX_SIZE);
-      for (Integer key : rand_nums) assertEquals(map.add(key, key), map2.put(key, key));
+      for (Integer key : rand_nums) assertThat(map.add(key, key)).isEqualTo(map2.put(key, key));
 
       int count = 0;
       for (Integer key : map) {
-        assertEquals(key, map.get(key));
-        assertEquals(map.get(key), map2.get(key));
-        assertTrue(map.hasKey(key));
-        assertTrue(rand_nums.contains(key));
+        assertThat(map.get(key)).isEqualTo(key);;
+        assertThat(map.get(key)).isEqualTo(map2.get(key));
+        assertThat(map.hasKey(key)).isTrue();
+        assertThat(rand_nums.contains(key)).isTrue();
         count++;
       }
 
       for (Integer key : map2.keySet()) {
-        assertEquals(key, map.get(key));
+        assertThat(map.get(key)).isEqualTo(key);
       }
 
       Set<Integer> set = new HashSet<>();
       for (int n : rand_nums) set.add(n);
 
-      assertEquals(set.size(), count);
-      assertEquals(map2.size(), count);
+      assertThat(set.size()).isEqualTo(count);
+      assertThat(map2.size()).isEqualTo(count);
     }
   }
 
@@ -154,12 +154,12 @@ public class HashTableLinearProbingTest {
         map.put(randomVal, 5);
       }
 
-      assertEquals(map.size(), keys_set.size());
+      assertThat(map.size()).isEqualTo(keys_set.size());
 
       List<Integer> keys = map.keys();
       for (Integer key : keys) map.remove(key);
 
-      assertTrue(map.isEmpty());
+      assertThat(map.isEmpty()).isTrue();;
     }
   }
 
@@ -172,21 +172,21 @@ public class HashTableLinearProbingTest {
     map.put(11, 0);
     map.put(12, 0);
     map.put(13, 0);
-    assertEquals(3, map.size());
+    assertThat(map.size()).isEqualTo(3);
 
     // Add ten more
     for (int i = 1; i <= 10; i++) map.put(i, 0);
-    assertEquals(13, map.size());
+    assertThat(map.size()).isEqualTo(13);
 
     // Remove ten
     for (int i = 1; i <= 10; i++) map.remove(i);
-    assertEquals(3, map.size());
+    assertThat(map.size()).isEqualTo(3);
 
     // remove three
     map.remove(11);
     map.remove(12);
     map.remove(13);
-    assertEquals(0, map.size());
+    assertThat(map.size()).isEqualTo(0);
   }
 
   @Test
@@ -209,7 +209,7 @@ public class HashTableLinearProbingTest {
     map.remove(o1);
     map.remove(o4);
 
-    assertEquals(0, map.size());
+    assertThat(map.size()).isEqualTo(0);
   }
 
   @Test
@@ -221,7 +221,7 @@ public class HashTableLinearProbingTest {
 
       map.clear();
       jmap.clear();
-      assertEquals(jmap.size(), map.size());
+      assertThat(jmap.size()).isEqualTo(map.size());
 
       map = new HashTableLinearProbing<>();
 
@@ -236,17 +236,17 @@ public class HashTableLinearProbingTest {
         int key = nums.get(i);
         int val = i;
 
-        if (r < probability1) assertEquals(jmap.put(key, val), map.put(key, val));
+        if (r < probability1) assertThat(jmap.put(key, val)).isEqualTo(map.put(key, val));
 
-        assertEquals(jmap.get(key), map.get(key));
-        assertEquals(jmap.containsKey(key), map.containsKey(key));
-        assertEquals(jmap.size(), map.size());
+        assertThat(jmap.get(key)).isEqualTo(map.get(key));
+        assertThat(jmap.containsKey(key)).isEqualTo(map.containsKey(key));
+        assertThat(jmap.size()).isEqualTo(map.size());
 
-        if (r > probability2) assertEquals(map.remove(key), jmap.remove(key));
+        if (r > probability2) assertThat(map.remove(key)).isEqualTo(jmap.remove(key));
 
-        assertEquals(jmap.get(key), map.get(key));
-        assertEquals(jmap.containsKey(key), map.containsKey(key));
-        assertEquals(jmap.size(), map.size());
+        assertThat(jmap.get(key)).isEqualTo(map.get(key));
+        assertThat(jmap.containsKey(key)).isEqualTo(map.containsKey(key));
+        assertThat(jmap.size()).isEqualTo(map.size());
       }
     }
   }
@@ -261,7 +261,7 @@ public class HashTableLinearProbingTest {
 
       m.clear();
       hm.clear();
-      assertEquals(m.size(), hm.size());
+      assertThat(m.size()).isEqualTo(hm.size());
 
       int sz = randInt(1, MAX_SIZE);
       m = new HashTableLinearProbing<>(sz);
@@ -295,8 +295,8 @@ public class HashTableLinearProbingTest {
           l2.add(rand_val);
         }
 
-        assertEquals(m.size(), hm.size());
-        assertEquals(l1, l2);
+        assertThat(m.size()).isEqualTo(hm.size());
+        assertThat(l1).isEqualTo(l2);
       }
     }
   }

--- a/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableLinearProbingTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableLinearProbingTest.java
@@ -77,7 +77,8 @@ public class HashTableLinearProbingTest {
     assertThat(map.get(1)).isEqualTo(1);
 
     map.add(1, 5);
-    assertThat(map.get(1)).isEqualTo(5);;
+    assertThat(map.get(1)).isEqualTo(5);
+    ;
 
     map.add(1, -7);
     assertThat(map.get(1)).isEqualTo(-7);
@@ -92,7 +93,8 @@ public class HashTableLinearProbingTest {
 
       map.clear();
       map2.clear();
-      assertThat(map.isEmpty()).isTrue();;
+      assertThat(map.isEmpty()).isTrue();
+      ;
 
       map = new HashTableLinearProbing<>();
 
@@ -101,7 +103,8 @@ public class HashTableLinearProbingTest {
 
       int count = 0;
       for (Integer key : map) {
-        assertThat(map.get(key)).isEqualTo(key);;
+        assertThat(map.get(key)).isEqualTo(key);
+        ;
         assertThat(map.get(key)).isEqualTo(map2.get(key));
         assertThat(map.hasKey(key)).isTrue();
         assertThat(rand_nums.contains(key)).isTrue();
@@ -159,7 +162,8 @@ public class HashTableLinearProbingTest {
       List<Integer> keys = map.keys();
       for (Integer key : keys) map.remove(key);
 
-      assertThat(map.isEmpty()).isTrue();;
+      assertThat(map.isEmpty()).isTrue();
+      ;
     }
   }
 

--- a/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableQuadraticProbingTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableQuadraticProbingTest.java
@@ -1,6 +1,6 @@
 package com.williamfiset.algorithms.datastructures.hashtable;
 
-import static org.junit.Assert.*;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.util.*;
 import org.junit.*;
@@ -74,19 +74,19 @@ public class HashTableQuadraticProbingTest {
   public void testUpdatingValue() {
 
     map.add(1, 1);
-    assertTrue(1 == map.get(1));
+    assertThat(map.get(1)).isEqualTo(1);
 
     map.add(1, 5);
-    assertTrue(5 == map.get(1));
+    assertThat(map.get(1)).isEqualTo(5);
 
     map.add(1, -7);
-    assertTrue(-7 == map.get(1));
+    assertThat(map.get(1)).isEqualTo(-7);
   }
 
   private void assertCapacityIsPowerOfTwo(HashTableQuadraticProbing<Integer, Integer> ht) {
     int sz = ht.getCapacity();
     if (sz == 0) return;
-    assertTrue((sz & (sz - 1)) == 0);
+    assertThat((sz & (sz - 1))).isEqualTo(0);
   }
 
   // Test that as the table size increases the hashtable
@@ -113,31 +113,31 @@ public class HashTableQuadraticProbingTest {
 
       map.clear();
       map2.clear();
-      assertTrue(map.isEmpty());
+      assertThat(map.isEmpty()).isTrue();
 
       map = new HashTableQuadraticProbing<>();
 
       List<Integer> rand_nums = genRandList(MAX_SIZE);
-      for (Integer key : rand_nums) assertEquals(map.add(key, key), map2.put(key, key));
+      for (Integer key : rand_nums) assertThat(map.add(key, key)).isEqualTo(map2.put(key, key));
 
       int count = 0;
       for (Integer key : map) {
-        assertEquals(key, map.get(key));
-        assertEquals(map.get(key), map2.get(key));
-        assertTrue(map.hasKey(key));
-        assertTrue(rand_nums.contains(key));
+        assertThat(map.get(key)).isEqualTo(key);;
+        assertThat(map.get(key)).isEqualTo(map2.get(key));
+        assertThat(map.hasKey(key)).isTrue();
+        assertThat(rand_nums.contains(key)).isTrue();
         count++;
       }
 
       for (Integer key : map2.keySet()) {
-        assertEquals(key, map.get(key));
+        assertThat(map.get(key)).isEqualTo(key);
       }
 
       Set<Integer> set = new HashSet<>();
       for (int n : rand_nums) set.add(n);
 
-      assertEquals(set.size(), count);
-      assertEquals(map2.size(), count);
+      assertThat(set.size()).isEqualTo(count);
+      assertThat(map2.size()).isEqualTo(count);
     }
   }
 
@@ -175,12 +175,12 @@ public class HashTableQuadraticProbingTest {
         map.put(randomVal, 5);
       }
 
-      assertEquals(map.size(), keys_set.size());
+      assertThat(map.size()).isEqualTo(keys_set.size());
 
       List<Integer> keys = map.keys();
       for (Integer key : keys) map.remove(key);
 
-      assertTrue(map.isEmpty());
+      assertThat(map.isEmpty()).isTrue();
     }
   }
 
@@ -193,21 +193,21 @@ public class HashTableQuadraticProbingTest {
     map.put(11, 0);
     map.put(12, 0);
     map.put(13, 0);
-    assertEquals(3, map.size());
+    assertThat(map.size()).isEqualTo(3);
 
     // Add ten more
     for (int i = 1; i <= 10; i++) map.put(i, 0);
-    assertEquals(13, map.size());
+    assertThat(map.size()).isEqualTo(13);
 
     // Remove ten
     for (int i = 1; i <= 10; i++) map.remove(i);
-    assertEquals(3, map.size());
+    assertThat(map.size()).isEqualTo(3);
 
     // remove three
     map.remove(11);
     map.remove(12);
     map.remove(13);
-    assertEquals(0, map.size());
+    assertThat(map.size()).isEqualTo(0);
   }
 
   @Test
@@ -230,7 +230,7 @@ public class HashTableQuadraticProbingTest {
     map.remove(o1);
     map.remove(o4);
 
-    assertEquals(0, map.size());
+    assertThat(map.size()).isEqualTo(0);
   }
 
   @Test
@@ -242,7 +242,7 @@ public class HashTableQuadraticProbingTest {
 
       map.clear();
       jmap.clear();
-      assertEquals(jmap.size(), map.size());
+      assertThat(jmap.size()).isEqualTo(map.size());
 
       map = new HashTableQuadraticProbing<>();
 
@@ -257,17 +257,17 @@ public class HashTableQuadraticProbingTest {
         int key = nums.get(i);
         int val = i;
 
-        if (r < probability1) assertEquals(jmap.put(key, val), map.put(key, val));
+        if (r < probability1) assertThat(jmap.put(key, val)).isEqualTo(map.put(key, val));
 
-        assertEquals(jmap.get(key), map.get(key));
-        assertEquals(jmap.containsKey(key), map.containsKey(key));
-        assertEquals(jmap.size(), map.size());
+        assertThat(jmap.get(key)).isEqualTo(map.get(key));
+        assertThat(jmap.containsKey(key)).isEqualTo(map.containsKey(key));
+        assertThat(jmap.size()).isEqualTo(map.size());
 
-        if (r > probability2) assertEquals(map.remove(key), jmap.remove(key));
+        if (r > probability2) assertThat(map.remove(key)).isEqualTo(jmap.remove(key));
 
-        assertEquals(jmap.get(key), map.get(key));
-        assertEquals(jmap.containsKey(key), map.containsKey(key));
-        assertEquals(jmap.size(), map.size());
+        assertThat(jmap.get(key)).isEqualTo(map.get(key));
+        assertThat(jmap.containsKey(key)).isEqualTo(map.containsKey(key));
+        assertThat(jmap.size()).isEqualTo(map.size());
       }
     }
   }
@@ -282,7 +282,7 @@ public class HashTableQuadraticProbingTest {
 
       m.clear();
       hm.clear();
-      assertEquals(m.size(), hm.size());
+      assertThat(m.size()).isEqualTo(hm.size());
 
       int sz = randInt(1, MAX_SIZE);
       m = new HashTableQuadraticProbing<>(sz);
@@ -316,8 +316,8 @@ public class HashTableQuadraticProbingTest {
           l2.add(rand_val);
         }
 
-        assertEquals(m.size(), hm.size());
-        assertEquals(l1, l2);
+        assertThat(m.size()).isEqualTo(hm.size());
+        assertThat(l1).isEqualTo(l2);
       }
     }
   }

--- a/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableQuadraticProbingTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableQuadraticProbingTest.java
@@ -122,7 +122,8 @@ public class HashTableQuadraticProbingTest {
 
       int count = 0;
       for (Integer key : map) {
-        assertThat(map.get(key)).isEqualTo(key);;
+        assertThat(map.get(key)).isEqualTo(key);
+        ;
         assertThat(map.get(key)).isEqualTo(map2.get(key));
         assertThat(map.hasKey(key)).isTrue();
         assertThat(rand_nums.contains(key)).isTrue();

--- a/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableQuadraticProbingTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableQuadraticProbingTest.java
@@ -123,7 +123,6 @@ public class HashTableQuadraticProbingTest {
       int count = 0;
       for (Integer key : map) {
         assertThat(map.get(key)).isEqualTo(key);
-        ;
         assertThat(map.get(key)).isEqualTo(map2.get(key));
         assertThat(map.hasKey(key)).isTrue();
         assertThat(rand_nums.contains(key)).isTrue();

--- a/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableSeparateChainingTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableSeparateChainingTest.java
@@ -105,13 +105,11 @@ public class HashTableSeparateChainingTest {
         assertThat(map.get(key)).isEqualTo(map2.get(key));
         assertThat(map.hasKey(key)).isTrue();
         assertThat(rand_nums.contains(key)).isTrue();
-        ;
         count++;
       }
 
       for (Integer key : map2.keySet()) {
         assertThat(map.get(key)).isEqualTo(key);
-        ;
       }
 
       Set<Integer> set = new HashSet<>();

--- a/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableSeparateChainingTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableSeparateChainingTest.java
@@ -104,12 +104,14 @@ public class HashTableSeparateChainingTest {
         assertThat(map.get(key)).isEqualTo(key);
         assertThat(map.get(key)).isEqualTo(map2.get(key));
         assertThat(map.hasKey(key)).isTrue();
-        assertThat(rand_nums.contains(key)).isTrue();;
+        assertThat(rand_nums.contains(key)).isTrue();
+        ;
         count++;
       }
 
       for (Integer key : map2.keySet()) {
-        assertThat(map.get(key)).isEqualTo(key);;
+        assertThat(map.get(key)).isEqualTo(key);
+        ;
       }
 
       Set<Integer> set = new HashSet<>();

--- a/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableSeparateChainingTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableSeparateChainingTest.java
@@ -1,6 +1,6 @@
 package com.williamfiset.algorithms.datastructures.hashtable;
 
-import static org.junit.Assert.*;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.util.*;
 import org.junit.*;
@@ -74,13 +74,13 @@ public class HashTableSeparateChainingTest {
   public void testUpdatingValue() {
 
     map.add(1, 1);
-    assertTrue(1 == map.get(1));
+    assertThat(map.get(1)).isEqualTo(1);
 
     map.add(1, 5);
-    assertTrue(5 == map.get(1));
+    assertThat(map.get(1)).isEqualTo(5);
 
     map.add(1, -7);
-    assertTrue(-7 == map.get(1));
+    assertThat(map.get(1)).isEqualTo(-7);
   }
 
   @Test
@@ -92,31 +92,31 @@ public class HashTableSeparateChainingTest {
 
       map.clear();
       map2.clear();
-      assertTrue(map.isEmpty());
+      assertThat(map.isEmpty()).isTrue();
 
       map = new HashTableSeparateChaining<>();
 
       List<Integer> rand_nums = genRandList(MAX_SIZE);
-      for (Integer key : rand_nums) assertEquals(map.add(key, key), map2.put(key, key));
+      for (Integer key : rand_nums) assertThat(map.add(key, key)).isEqualTo(map2.put(key, key));
 
       int count = 0;
       for (Integer key : map) {
-        assertEquals(key, map.get(key));
-        assertEquals(map.get(key), map2.get(key));
-        assertTrue(map.hasKey(key));
-        assertTrue(rand_nums.contains(key));
+        assertThat(map.get(key)).isEqualTo(key);
+        assertThat(map.get(key)).isEqualTo(map2.get(key));
+        assertThat(map.hasKey(key)).isTrue();
+        assertThat(rand_nums.contains(key)).isTrue();;
         count++;
       }
 
       for (Integer key : map2.keySet()) {
-        assertEquals(key, map.get(key));
+        assertThat(map.get(key)).isEqualTo(key);;
       }
 
       Set<Integer> set = new HashSet<>();
       for (int n : rand_nums) set.add(n);
 
-      assertEquals(set.size(), count);
-      assertEquals(map2.size(), count);
+      assertThat(set.size()).isEqualTo(count);
+      assertThat(map2.size()).isEqualTo(count);
     }
   }
 
@@ -154,12 +154,12 @@ public class HashTableSeparateChainingTest {
         map.put(randomVal, 5);
       }
 
-      assertEquals(map.size(), keys_set.size());
+      assertThat(map.size()).isEqualTo(keys_set.size());
 
       List<Integer> keys = map.keys();
       for (Integer key : keys) map.remove(key);
 
-      assertTrue(map.isEmpty());
+      assertThat(map.isEmpty()).isTrue();
     }
   }
 
@@ -172,21 +172,21 @@ public class HashTableSeparateChainingTest {
     map.put(11, 0);
     map.put(12, 0);
     map.put(13, 0);
-    assertEquals(3, map.size());
+    assertThat(map.size()).isEqualTo(3);
 
     // Add ten more
     for (int i = 1; i <= 10; i++) map.put(i, 0);
-    assertEquals(13, map.size());
+    assertThat(map.size()).isEqualTo(13);
 
     // Remove ten
     for (int i = 1; i <= 10; i++) map.remove(i);
-    assertEquals(3, map.size());
+    assertThat(map.size()).isEqualTo(3);
 
     // remove three
     map.remove(11);
     map.remove(12);
     map.remove(13);
-    assertEquals(0, map.size());
+    assertThat(map.size()).isEqualTo(0);
   }
 
   @Test
@@ -209,7 +209,7 @@ public class HashTableSeparateChainingTest {
     map.remove(o1);
     map.remove(o4);
 
-    assertEquals(0, map.size());
+    assertThat(map.size()).isEqualTo(0);
   }
 
   @Test
@@ -221,7 +221,7 @@ public class HashTableSeparateChainingTest {
 
       map.clear();
       jmap.clear();
-      assertEquals(jmap.size(), map.size());
+      assertThat(jmap.size()).isEqualTo(map.size());
 
       map = new HashTableSeparateChaining<>();
 
@@ -236,17 +236,17 @@ public class HashTableSeparateChainingTest {
         int key = nums.get(i);
         int val = i;
 
-        if (r < probability1) assertEquals(jmap.put(key, val), map.put(key, val));
+        if (r < probability1) assertThat(jmap.put(key, val)).isEqualTo(map.put(key, val));
 
-        assertEquals(jmap.get(key), map.get(key));
-        assertEquals(jmap.containsKey(key), map.containsKey(key));
-        assertEquals(jmap.size(), map.size());
+        assertThat(jmap.get(key)).isEqualTo(map.get(key));
+        assertThat(jmap.containsKey(key)).isEqualTo(map.containsKey(key));
+        assertThat(jmap.size()).isEqualTo(map.size());
 
-        if (r > probability2) assertEquals(map.remove(key), jmap.remove(key));
+        if (r > probability2) assertThat(map.remove(key)).isEqualTo(jmap.remove(key));
 
-        assertEquals(jmap.get(key), map.get(key));
-        assertEquals(jmap.containsKey(key), map.containsKey(key));
-        assertEquals(jmap.size(), map.size());
+        assertThat(jmap.get(key)).isEqualTo(map.get(key));
+        assertThat(jmap.containsKey(key)).isEqualTo(map.containsKey(key));
+        assertThat(jmap.size()).isEqualTo(map.size());
       }
     }
   }
@@ -261,7 +261,7 @@ public class HashTableSeparateChainingTest {
 
       m.clear();
       hm.clear();
-      assertEquals(m.size(), hm.size());
+      assertThat(m.size()).isEqualTo(hm.size());
 
       int sz = randInt(1, MAX_SIZE);
       m = new HashTableSeparateChaining<>(sz);
@@ -295,8 +295,8 @@ public class HashTableSeparateChainingTest {
           l2.add(rand_val);
         }
 
-        assertEquals(m.size(), hm.size());
-        assertEquals(l1, l2);
+        assertThat(m.size()).isEqualTo(hm.size());
+        assertThat(l1).isEqualTo(l2);
       }
     }
   }

--- a/src/test/java/com/williamfiset/algorithms/datastructures/linkedlist/LinkedListTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/linkedlist/LinkedListTest.java
@@ -22,7 +22,8 @@ public class LinkedListTest {
 
   @Test
   public void testEmptyList() {
-    assertThat(list.isEmpty()).isTrue();;
+    assertThat(list.isEmpty()).isTrue();
+    ;
     assertThat(list.size()).isEqualTo(0);
   }
 
@@ -87,7 +88,8 @@ public class LinkedListTest {
   public void testRemoveLast() {
     list.addLast(4);
     assertThat(list.removeLast()).isEqualTo(4);
-    assertThat(list.isEmpty()).isTrue();;
+    assertThat(list.isEmpty()).isTrue();
+    ;
   }
 
   @Test
@@ -134,7 +136,7 @@ public class LinkedListTest {
     // 7 - 6
     list.removeLast();
     assertThat(list.peekFirst()).isEqualTo(7);
-    assertThat(list.peekLast()).isEqualTo( 6);
+    assertThat(list.peekLast()).isEqualTo(6);
 
     // 6
     list.removeFirst();

--- a/src/test/java/com/williamfiset/algorithms/datastructures/linkedlist/LinkedListTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/linkedlist/LinkedListTest.java
@@ -1,6 +1,6 @@
 package com.williamfiset.algorithms.datastructures.linkedlist;
 
-import static org.junit.Assert.*;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -22,8 +22,8 @@ public class LinkedListTest {
 
   @Test
   public void testEmptyList() {
-    assertTrue(list.isEmpty());
-    assertEquals(list.size(), 0);
+    assertThat(list.isEmpty()).isTrue();;
+    assertThat(list.size()).isEqualTo(0);
   }
 
   @Test(expected = Exception.class)
@@ -49,97 +49,97 @@ public class LinkedListTest {
   @Test
   public void testAddFirst() {
     list.addFirst(3);
-    assertEquals(list.size(), 1);
+    assertThat(list.size()).isEqualTo(1);
     list.addFirst(5);
-    assertEquals(list.size(), 2);
+    assertThat(list.size()).isEqualTo(2);
   }
 
   @Test
   public void testAddLast() {
     list.addLast(3);
-    assertEquals(list.size(), 1);
+    assertThat(list.size()).isEqualTo(1);
     list.addLast(5);
-    assertEquals(list.size(), 2);
+    assertThat(list.size()).isEqualTo(2);
   }
 
   @Test
   public void testAddAt() throws Exception {
     list.addAt(0, 1);
-    assertEquals(list.size(), 1);
+    assertThat(list.size()).isEqualTo(1);
     list.addAt(1, 2);
-    assertEquals(list.size(), 2);
+    assertThat(list.size()).isEqualTo(2);
     list.addAt(1, 3);
-    assertEquals(list.size(), 3);
+    assertThat(list.size()).isEqualTo(3);
     list.addAt(2, 4);
-    assertEquals(list.size(), 4);
+    assertThat(list.size()).isEqualTo(4);
     list.addAt(1, 8);
-    assertEquals(list.size(), 5);
+    assertThat(list.size()).isEqualTo(5);
   }
 
   @Test
   public void testRemoveFirst() {
     list.addFirst(3);
-    assertTrue(list.removeFirst() == 3);
-    assertTrue(list.isEmpty());
+    assertThat(list.removeFirst()).isEqualTo(3);
+    assertThat(list.isEmpty());
   }
 
   @Test
   public void testRemoveLast() {
     list.addLast(4);
-    assertTrue(list.removeLast() == 4);
-    assertTrue(list.isEmpty());
+    assertThat(list.removeLast()).isEqualTo(4);
+    assertThat(list.isEmpty()).isTrue();;
   }
 
   @Test
   public void testPeekFirst() {
     list.addFirst(4);
-    assertTrue(list.peekFirst() == 4);
-    assertEquals(list.size(), 1);
+    assertThat(list.peekFirst()).isEqualTo(4);
+    assertThat(list.size()).isEqualTo(1);
   }
 
   @Test
   public void testPeekLast() {
     list.addLast(4);
-    assertTrue(list.peekLast() == 4);
-    assertEquals(list.size(), 1);
+    assertThat(list.peekLast()).isEqualTo(4);
+    assertThat(list.size()).isEqualTo(1);
   }
 
   @Test
   public void testPeeking() {
     // 5
     list.addFirst(5);
-    assertTrue(list.peekFirst() == 5);
-    assertTrue(list.peekLast() == 5);
+    assertThat(list.peekFirst()).isEqualTo(5);
+    assertThat(list.peekLast()).isEqualTo(5);
 
     // 6 - 5
     list.addFirst(6);
-    assertTrue(list.peekFirst() == 6);
-    assertTrue(list.peekLast() == 5);
+    assertThat(list.peekFirst()).isEqualTo(6);
+    assertThat(list.peekLast()).isEqualTo(5);
 
     // 7 - 6 - 5
     list.addFirst(7);
-    assertTrue(list.peekFirst() == 7);
-    assertTrue(list.peekLast() == 5);
+    assertThat(list.peekFirst()).isEqualTo(7);
+    assertThat(list.peekLast()).isEqualTo(5);
 
     // 7 - 6 - 5 - 8
     list.addLast(8);
-    assertTrue(list.peekFirst() == 7);
-    assertTrue(list.peekLast() == 8);
+    assertThat(list.peekFirst()).isEqualTo(7);
+    assertThat(list.peekLast()).isEqualTo(8);
 
     // 7 - 6 - 5
     list.removeLast();
-    assertTrue(list.peekFirst() == 7);
-    assertTrue(list.peekLast() == 5);
+    assertThat(list.peekFirst()).isEqualTo(7);
+    assertThat(list.peekLast()).isEqualTo(5);
 
     // 7 - 6
     list.removeLast();
-    assertTrue(list.peekFirst() == 7);
-    assertTrue(list.peekLast() == 6);
+    assertThat(list.peekFirst()).isEqualTo(7);
+    assertThat(list.peekLast()).isEqualTo( 6);
 
     // 6
     list.removeFirst();
-    assertTrue(list.peekFirst() == 6);
-    assertTrue(list.peekLast() == 6);
+    assertThat(list.peekFirst()).isEqualTo(6);
+    assertThat(list.peekLast()).isEqualTo(6);
   }
 
   @Test
@@ -157,7 +157,7 @@ public class LinkedListTest {
     strs.remove("e");
     strs.remove("c");
     strs.remove("f");
-    assertEquals(0, strs.size());
+    assertThat(strs.size()).isEqualTo(0);
   }
 
   @Test
@@ -168,11 +168,11 @@ public class LinkedListTest {
     list.add(4);
     list.removeAt(0);
     list.removeAt(2);
-    assertTrue(list.peekFirst() == 2);
-    assertTrue(list.peekLast() == 3);
+    assertThat(list.peekFirst()).isEqualTo(2);
+    assertThat(list.peekLast()).isEqualTo(3);
     list.removeAt(1);
     list.removeAt(0);
-    assertEquals(list.size(), 0);
+    assertThat(list.size()).isEqualTo(0);
   }
 
   @Test
@@ -180,15 +180,15 @@ public class LinkedListTest {
     list.add(22);
     list.add(33);
     list.add(44);
-    assertEquals(list.size(), 3);
+    assertThat(list.size()).isEqualTo(3);
     list.clear();
-    assertEquals(list.size(), 0);
+    assertThat(list.size()).isEqualTo(0);
     list.add(22);
     list.add(33);
     list.add(44);
-    assertEquals(list.size(), 3);
+    assertThat(list.size()).isEqualTo(3);
     list.clear();
-    assertEquals(list.size(), 0);
+    assertThat(list.size()).isEqualTo(0);
   }
 
   @Test
@@ -210,16 +210,16 @@ public class LinkedListTest {
       for (int i = 0; i < randNums.size(); i++) {
 
         Integer rm_val = randNums.get(i);
-        assertEquals(javaLinkedList.remove(rm_val), list.remove(rm_val));
-        assertEquals(javaLinkedList.size(), list.size());
+        assertThat(javaLinkedList.remove(rm_val)).isEqualTo(list.remove(rm_val));
+        assertThat(javaLinkedList.size()).isEqualTo(list.size());
 
         java.util.Iterator<Integer> iter1 = javaLinkedList.iterator();
         java.util.Iterator<Integer> iter2 = list.iterator();
-        while (iter1.hasNext()) assertEquals(iter1.next(), iter2.next());
+        while (iter1.hasNext()) assertThat(iter1.next()).isEqualTo(iter2.next());
 
         iter1 = javaLinkedList.iterator();
         iter2 = list.iterator();
-        while (iter1.hasNext()) assertEquals(iter1.next(), iter2.next());
+        while (iter1.hasNext()) assertThat(iter1.next()).isEqualTo(iter2.next());
       }
 
       list.clear();
@@ -234,12 +234,12 @@ public class LinkedListTest {
       for (int i = 0; i < randNums.size(); i++) {
 
         Integer rm_val = (int) (MAX_RAND_NUM * Math.random());
-        assertEquals(javaLinkedList.remove(rm_val), list.remove(rm_val));
-        assertEquals(javaLinkedList.size(), list.size());
+        assertThat(javaLinkedList.remove(rm_val)).isEqualTo(list.remove(rm_val));
+        assertThat(javaLinkedList.size()).isEqualTo(list.size());
 
         java.util.Iterator<Integer> iter1 = javaLinkedList.iterator();
         java.util.Iterator<Integer> iter2 = list.iterator();
-        while (iter1.hasNext()) assertEquals(iter1.next(), iter2.next());
+        while (iter1.hasNext()) assertThat(iter1.next()).isEqualTo(iter2.next());
       }
     }
   }
@@ -266,12 +266,12 @@ public class LinkedListTest {
 
         Integer num1 = javaLinkedList.remove(rm_index);
         Integer num2 = list.removeAt(rm_index);
-        assertEquals(num1, num2);
-        assertEquals(javaLinkedList.size(), list.size());
+        assertThat(num1).isEqualTo(num2);
+        assertThat(javaLinkedList.size()).isEqualTo(list.size());
 
         java.util.Iterator<Integer> iter1 = javaLinkedList.iterator();
         java.util.Iterator<Integer> iter2 = list.iterator();
-        while (iter1.hasNext()) assertEquals(iter1.next(), iter2.next());
+        while (iter1.hasNext()) assertThat(iter1.next()).isEqualTo(iter2.next());
       }
     }
   }
@@ -299,12 +299,12 @@ public class LinkedListTest {
         Integer index1 = javaLinkedList.indexOf(elem);
         Integer index2 = list.indexOf(elem);
 
-        assertEquals(index1, index2);
-        assertEquals(javaLinkedList.size(), list.size());
+        assertThat(index1).isEqualTo(index2);
+        assertThat(javaLinkedList.size()).isEqualTo(list.size());
 
         java.util.Iterator<Integer> iter1 = javaLinkedList.iterator();
         java.util.Iterator<Integer> iter2 = list.iterator();
-        while (iter1.hasNext()) assertEquals(iter1.next(), iter2.next());
+        while (iter1.hasNext()) assertThat(iter1.next()).isEqualTo(iter2.next());
       }
     }
   }
@@ -312,16 +312,16 @@ public class LinkedListTest {
   @Test
   public void testToString() {
     DoublyLinkedList<String> strs = new DoublyLinkedList<>();
-    assertEquals(strs.toString(), "[  ]");
+    assertThat(strs.toString()).isEqualTo("[  ]");
     strs.add("a");
-    assertEquals(strs.toString(), "[ a ]");
+    assertThat(strs.toString()).isEqualTo("[ a ]");
     strs.add("b");
-    assertEquals(strs.toString(), "[ a, b ]");
+    assertThat(strs.toString()).isEqualTo("[ a, b ]");
     strs.add("c");
     strs.add("d");
     strs.add("e");
     strs.add("f");
-    assertEquals(strs.toString(), "[ a, b, c, d, e, f ]");
+    assertThat(strs.toString()).isEqualTo("[ a, b, c, d, e, f ]");
   }
 
   // Generate a list of random numbers

--- a/src/test/java/com/williamfiset/algorithms/datastructures/linkedlist/LinkedListTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/linkedlist/LinkedListTest.java
@@ -23,7 +23,6 @@ public class LinkedListTest {
   @Test
   public void testEmptyList() {
     assertThat(list.isEmpty()).isTrue();
-    ;
     assertThat(list.size()).isEqualTo(0);
   }
 
@@ -89,7 +88,6 @@ public class LinkedListTest {
     list.addLast(4);
     assertThat(list.removeLast()).isEqualTo(4);
     assertThat(list.isEmpty()).isTrue();
-    ;
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/priorityqueue/BinaryHeapQuickRemovalsTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/priorityqueue/BinaryHeapQuickRemovalsTest.java
@@ -20,7 +20,8 @@ public class BinaryHeapQuickRemovalsTest {
   public void testEmpty() {
     BinaryHeapQuickRemovals<Integer> q = new BinaryHeapQuickRemovals<>();
     assertThat(q.size()).isEqualTo(0);
-    assertThat(q.isEmpty()).isTrue();;
+    assertThat(q.isEmpty()).isTrue();
+    ;
     assertThat(q.poll()).isNull();
     assertThat(q.peek()).isNull();
   }
@@ -53,7 +54,8 @@ public class BinaryHeapQuickRemovalsTest {
       PriorityQueue<Integer> pq2 = new PriorityQueue<>(i);
       for (int x : lst) pq2.add(x);
 
-      assertThat(pq.isMinHeap(0)).isTrue();;
+      assertThat(pq.isMinHeap(0)).isTrue();
+      ;
       while (!pq2.isEmpty()) {
         assertThat(pq.poll()).isEqualTo(pq2.poll());
       }
@@ -68,7 +70,8 @@ public class BinaryHeapQuickRemovalsTest {
     q = new BinaryHeapQuickRemovals<>(strs);
     q.clear();
     assertThat(q.size()).isEqualTo(0);
-    assertThat(q.isEmpty()).isTrue();;
+    assertThat(q.isEmpty()).isTrue();
+    ;
   }
 
   @Test
@@ -120,7 +123,8 @@ public class BinaryHeapQuickRemovalsTest {
     PriorityQueue<Integer> PQ = new PriorityQueue<>();
     for (int value : in) PQ.offer(value);
 
-    assertThat(pq.isMinHeap(0)).isTrue();;
+    assertThat(pq.isMinHeap(0)).isTrue();
+    ;
 
     for (int i = 0; i < removeOrder.length; i++) {
 
@@ -132,7 +136,8 @@ public class BinaryHeapQuickRemovalsTest {
       assertThat(pq.isMinHeap(0)).isTrue();
     }
 
-    assertThat(pq.isEmpty()).isTrue();;
+    assertThat(pq.isEmpty()).isTrue();
+    ;
   }
 
   @Test
@@ -196,7 +201,8 @@ public class BinaryHeapQuickRemovalsTest {
 
       while (!pq1.isEmpty()) {
 
-        assertThat(pq2.isMinHeap(0)).isTrue();;
+        assertThat(pq2.isMinHeap(0)).isTrue();
+        ;
         assertThat(pq1.size()).isEqualTo(pq2.size());
         assertThat(pq1.peek()).isEqualTo(pq2.peek());
         assertThat(pq1.contains(pq1.peek())).isEqualTo(pq2.contains(pq2.peek()));
@@ -207,7 +213,8 @@ public class BinaryHeapQuickRemovalsTest {
         assertThat(v1).isEqualTo(v2);
         assertThat(pq1.peek()).isEqualTo(pq2.peek());
         assertThat(pq1.size()).isEqualTo(pq2.size());
-        assertThat(pq2.isMinHeap(0)).isTrue();;
+        assertThat(pq2.isMinHeap(0)).isTrue();
+        ;
       }
     }
   }
@@ -235,14 +242,16 @@ public class BinaryHeapQuickRemovalsTest {
 
         int removeNum = randNums.get(index++);
 
-        assertThat(pq2.isMinHeap(0)).isTrue();;
+        assertThat(pq2.isMinHeap(0)).isTrue();
+        ;
         assertThat(pq1.size()).isEqualTo(pq2.size());
         assertThat(pq1.peek()).isEqualTo(pq2.peek());
         pq1.remove(removeNum);
         pq2.remove(removeNum);
         assertThat(pq1.peek()).isEqualTo(pq2.peek());
         assertThat(pq1.size()).isEqualTo(pq2.size());
-        assertThat(pq2.isMinHeap(0)).isTrue();;
+        assertThat(pq2.isMinHeap(0)).isTrue();
+        ;
       }
     }
   }
@@ -279,7 +288,8 @@ public class BinaryHeapQuickRemovalsTest {
 
         int removeNum = nums.get(i);
 
-        assertThat(pq.isMinHeap(0)).isTrue();;
+        assertThat(pq.isMinHeap(0)).isTrue();
+        ;
         assertThat(PQ.size()).isEqualTo(pq.size());
         assertThat(PQ.peek()).isEqualTo(pq.peek());
 
@@ -288,7 +298,8 @@ public class BinaryHeapQuickRemovalsTest {
 
         assertThat(PQ.peek()).isEqualTo(pq.peek());
         assertThat(PQ.size()).isEqualTo(pq.size());
-        assertThat(pq.isMinHeap(0)).isTrue();;
+        assertThat(pq.isMinHeap(0)).isTrue();
+        ;
       }
     }
   }

--- a/src/test/java/com/williamfiset/algorithms/datastructures/priorityqueue/BinaryHeapQuickRemovalsTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/priorityqueue/BinaryHeapQuickRemovalsTest.java
@@ -174,8 +174,8 @@ public class BinaryHeapQuickRemovalsTest {
     assertThat(pq.poll()).isEqualTo(3);
     assertThat(pq.poll()).isEqualTo(7);
     assertThat(pq.poll()).isEqualTo(7);
-    assertThat(pq.poll()).isEqualTo( 11);
-    assertThat(pq.poll()).isEqualTo( 13);
+    assertThat(pq.poll()).isEqualTo(11);
+    assertThat(pq.poll()).isEqualTo(13);
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/priorityqueue/BinaryHeapQuickRemovalsTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/priorityqueue/BinaryHeapQuickRemovalsTest.java
@@ -1,6 +1,6 @@
 package com.williamfiset.algorithms.datastructures.priorityqueue;
 
-import static org.junit.Assert.*;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -19,10 +19,10 @@ public class BinaryHeapQuickRemovalsTest {
   @Test
   public void testEmpty() {
     BinaryHeapQuickRemovals<Integer> q = new BinaryHeapQuickRemovals<>();
-    assertEquals(q.size(), 0);
-    assertTrue(q.isEmpty());
-    assertEquals(q.poll(), null);
-    assertEquals(q.peek(), null);
+    assertThat(q.size()).isEqualTo(0);
+    assertThat(q.isEmpty()).isTrue();;
+    assertThat(q.poll()).isNull();
+    assertThat(q.peek()).isNull();
   }
 
   @Test
@@ -33,13 +33,13 @@ public class BinaryHeapQuickRemovalsTest {
 
     // Try manually creating heap
     for (int n : nums) q.add(n);
-    for (int i = 1; i <= 9; i++) assertTrue(i == q.poll());
+    for (int i = 1; i <= 9; i++) assertThat(q.poll()).isEqualTo(i);
 
     q.clear();
 
     // Try heapify constructor
     q = new BinaryHeapQuickRemovals<>(nums);
-    for (int i = 1; i <= 9; i++) assertTrue(i == q.poll());
+    for (int i = 1; i <= 9; i++) assertThat(q.poll()).isEqualTo(i);
   }
 
   @Test
@@ -53,9 +53,9 @@ public class BinaryHeapQuickRemovalsTest {
       PriorityQueue<Integer> pq2 = new PriorityQueue<>(i);
       for (int x : lst) pq2.add(x);
 
-      assertTrue(pq.isMinHeap(0));
+      assertThat(pq.isMinHeap(0)).isTrue();;
       while (!pq2.isEmpty()) {
-        assertEquals(pq.poll(), pq2.poll());
+        assertThat(pq.poll()).isEqualTo(pq2.poll());
       }
     }
   }
@@ -67,8 +67,8 @@ public class BinaryHeapQuickRemovalsTest {
     String[] strs = {"aa", "bb", "cc", "dd", "ee"};
     q = new BinaryHeapQuickRemovals<>(strs);
     q.clear();
-    assertEquals(q.size(), 0);
-    assertTrue(q.isEmpty());
+    assertThat(q.size()).isEqualTo(0);
+    assertThat(q.isEmpty()).isTrue();;
   }
 
   @Test
@@ -77,15 +77,15 @@ public class BinaryHeapQuickRemovalsTest {
     String[] strs = {"aa", "bb", "cc", "dd", "ee"};
     BinaryHeapQuickRemovals<String> q = new BinaryHeapQuickRemovals<>(strs);
     q.remove("aa");
-    assertFalse(q.contains("aa"));
+    assertThat(q.contains("aa")).isFalse();
     q.remove("bb");
-    assertFalse(q.contains("bb"));
+    assertThat(q.contains("bb")).isFalse();
     q.remove("cc");
-    assertFalse(q.contains("cc"));
+    assertThat(q.contains("cc")).isFalse();
     q.remove("dd");
-    assertFalse(q.contains("dd"));
+    assertThat(q.contains("dd")).isFalse();
     q.clear();
-    assertFalse(q.contains("ee"));
+    assertThat(q.contains("ee")).isFalse();
   }
 
   @Test
@@ -104,35 +104,35 @@ public class BinaryHeapQuickRemovalsTest {
       for (int j = 0; j < randNums.size(); j++) {
 
         int randVal = randNums.get(j);
-        assertEquals(pq.contains(randVal), PQ.contains(randVal));
+        assertThat(pq.contains(randVal)).isEqualTo(PQ.contains(randVal));
         pq.remove(randVal);
         PQ.remove(randVal);
-        assertEquals(pq.contains(randVal), PQ.contains(randVal));
+        assertThat(pq.contains(randVal)).isEqualTo(PQ.contains(randVal));
       }
     }
   }
 
   public void sequentialRemoving(Integer[] in, Integer[] removeOrder) {
 
-    assertEquals(in.length, removeOrder.length);
+    assertThat(in.length).isEqualTo(removeOrder.length);
 
     BinaryHeapQuickRemovals<Integer> pq = new BinaryHeapQuickRemovals<>(in);
     PriorityQueue<Integer> PQ = new PriorityQueue<>();
     for (int value : in) PQ.offer(value);
 
-    assertTrue(pq.isMinHeap(0));
+    assertThat(pq.isMinHeap(0)).isTrue();;
 
     for (int i = 0; i < removeOrder.length; i++) {
 
       int elem = removeOrder[i];
 
-      assertTrue(pq.peek() == PQ.peek());
-      assertEquals(pq.remove(elem), PQ.remove(elem));
-      assertTrue(pq.size() == PQ.size());
-      assertTrue(pq.isMinHeap(0));
+      assertThat(pq.peek()).isEqualTo(PQ.peek());
+      assertThat(pq.remove(elem)).isEqualTo(PQ.remove(elem));
+      assertThat(pq.size()).isEqualTo(PQ.size());
+      assertThat(pq.isMinHeap(0)).isTrue();
     }
 
-    assertTrue(pq.isEmpty());
+    assertThat(pq.isEmpty()).isTrue();;
   }
 
   @Test
@@ -165,17 +165,17 @@ public class BinaryHeapQuickRemovalsTest {
     Integer[] in = new Integer[] {2, 7, 2, 11, 7, 13, 2};
     BinaryHeapQuickRemovals<Integer> pq = new BinaryHeapQuickRemovals<>(in);
 
-    assertTrue(pq.peek() == 2);
+    assertThat(pq.peek()).isEqualTo(2);
     pq.add(3);
 
-    assertTrue(pq.poll() == 2);
-    assertTrue(pq.poll() == 2);
-    assertTrue(pq.poll() == 2);
-    assertTrue(pq.poll() == 3);
-    assertTrue(pq.poll() == 7);
-    assertTrue(pq.poll() == 7);
-    assertTrue(pq.poll() == 11);
-    assertTrue(pq.poll() == 13);
+    assertThat(pq.poll()).isEqualTo(2);
+    assertThat(pq.poll()).isEqualTo(2);
+    assertThat(pq.poll()).isEqualTo(2);
+    assertThat(pq.poll()).isEqualTo(3);
+    assertThat(pq.poll()).isEqualTo(7);
+    assertThat(pq.poll()).isEqualTo(7);
+    assertThat(pq.poll()).isEqualTo( 11);
+    assertThat(pq.poll()).isEqualTo( 13);
   }
 
   @Test
@@ -196,18 +196,18 @@ public class BinaryHeapQuickRemovalsTest {
 
       while (!pq1.isEmpty()) {
 
-        assertTrue(pq2.isMinHeap(0));
-        assertEquals(pq1.size(), pq2.size());
-        assertEquals(pq1.peek(), pq2.peek());
-        assertEquals(pq1.contains(pq1.peek()), pq2.contains(pq2.peek()));
+        assertThat(pq2.isMinHeap(0)).isTrue();;
+        assertThat(pq1.size()).isEqualTo(pq2.size());
+        assertThat(pq1.peek()).isEqualTo(pq2.peek());
+        assertThat(pq1.contains(pq1.peek())).isEqualTo(pq2.contains(pq2.peek()));
 
         Integer v1 = pq1.poll();
         Integer v2 = pq2.poll();
 
-        assertEquals(v1, v2);
-        assertEquals(pq1.peek(), pq2.peek());
-        assertEquals(pq1.size(), pq2.size());
-        assertTrue(pq2.isMinHeap(0));
+        assertThat(v1).isEqualTo(v2);
+        assertThat(pq1.peek()).isEqualTo(pq2.peek());
+        assertThat(pq1.size()).isEqualTo(pq2.size());
+        assertThat(pq2.isMinHeap(0)).isTrue();;
       }
     }
   }
@@ -235,14 +235,14 @@ public class BinaryHeapQuickRemovalsTest {
 
         int removeNum = randNums.get(index++);
 
-        assertTrue(pq2.isMinHeap(0));
-        assertEquals(pq1.size(), pq2.size());
-        assertEquals(pq1.peek(), pq2.peek());
+        assertThat(pq2.isMinHeap(0)).isTrue();;
+        assertThat(pq1.size()).isEqualTo(pq2.size());
+        assertThat(pq1.peek()).isEqualTo(pq2.peek());
         pq1.remove(removeNum);
         pq2.remove(removeNum);
-        assertEquals(pq1.peek(), pq2.peek());
-        assertEquals(pq1.size(), pq2.size());
-        assertTrue(pq2.isMinHeap(0));
+        assertThat(pq1.peek()).isEqualTo(pq2.peek());
+        assertThat(pq1.size()).isEqualTo(pq2.size());
+        assertThat(pq2.isMinHeap(0)).isTrue();;
       }
     }
   }
@@ -279,16 +279,16 @@ public class BinaryHeapQuickRemovalsTest {
 
         int removeNum = nums.get(i);
 
-        assertTrue(pq.isMinHeap(0));
-        assertEquals(PQ.size(), pq.size());
-        assertEquals(PQ.peek(), pq.peek());
+        assertThat(pq.isMinHeap(0)).isTrue();;
+        assertThat(PQ.size()).isEqualTo(pq.size());
+        assertThat(PQ.peek()).isEqualTo(pq.peek());
 
         PQ.remove(removeNum);
         pq.remove(removeNum);
 
-        assertEquals(PQ.peek(), pq.peek());
-        assertEquals(PQ.size(), pq.size());
-        assertTrue(pq.isMinHeap(0));
+        assertThat(PQ.peek()).isEqualTo(pq.peek());
+        assertThat(PQ.size()).isEqualTo(pq.size());
+        assertThat(pq.isMinHeap(0)).isTrue();;
       }
     }
   }

--- a/src/test/java/com/williamfiset/algorithms/datastructures/priorityqueue/BinaryHeapQuickRemovalsTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/priorityqueue/BinaryHeapQuickRemovalsTest.java
@@ -21,7 +21,6 @@ public class BinaryHeapQuickRemovalsTest {
     BinaryHeapQuickRemovals<Integer> q = new BinaryHeapQuickRemovals<>();
     assertThat(q.size()).isEqualTo(0);
     assertThat(q.isEmpty()).isTrue();
-    ;
     assertThat(q.poll()).isNull();
     assertThat(q.peek()).isNull();
   }
@@ -71,7 +70,6 @@ public class BinaryHeapQuickRemovalsTest {
     q.clear();
     assertThat(q.size()).isEqualTo(0);
     assertThat(q.isEmpty()).isTrue();
-    ;
   }
 
   @Test
@@ -124,7 +122,6 @@ public class BinaryHeapQuickRemovalsTest {
     for (int value : in) PQ.offer(value);
 
     assertThat(pq.isMinHeap(0)).isTrue();
-    ;
 
     for (int i = 0; i < removeOrder.length; i++) {
 
@@ -137,7 +134,6 @@ public class BinaryHeapQuickRemovalsTest {
     }
 
     assertThat(pq.isEmpty()).isTrue();
-    ;
   }
 
   @Test
@@ -202,7 +198,6 @@ public class BinaryHeapQuickRemovalsTest {
       while (!pq1.isEmpty()) {
 
         assertThat(pq2.isMinHeap(0)).isTrue();
-        ;
         assertThat(pq1.size()).isEqualTo(pq2.size());
         assertThat(pq1.peek()).isEqualTo(pq2.peek());
         assertThat(pq1.contains(pq1.peek())).isEqualTo(pq2.contains(pq2.peek()));
@@ -214,7 +209,6 @@ public class BinaryHeapQuickRemovalsTest {
         assertThat(pq1.peek()).isEqualTo(pq2.peek());
         assertThat(pq1.size()).isEqualTo(pq2.size());
         assertThat(pq2.isMinHeap(0)).isTrue();
-        ;
       }
     }
   }
@@ -243,7 +237,6 @@ public class BinaryHeapQuickRemovalsTest {
         int removeNum = randNums.get(index++);
 
         assertThat(pq2.isMinHeap(0)).isTrue();
-        ;
         assertThat(pq1.size()).isEqualTo(pq2.size());
         assertThat(pq1.peek()).isEqualTo(pq2.peek());
         pq1.remove(removeNum);
@@ -251,7 +244,6 @@ public class BinaryHeapQuickRemovalsTest {
         assertThat(pq1.peek()).isEqualTo(pq2.peek());
         assertThat(pq1.size()).isEqualTo(pq2.size());
         assertThat(pq2.isMinHeap(0)).isTrue();
-        ;
       }
     }
   }
@@ -289,7 +281,6 @@ public class BinaryHeapQuickRemovalsTest {
         int removeNum = nums.get(i);
 
         assertThat(pq.isMinHeap(0)).isTrue();
-        ;
         assertThat(PQ.size()).isEqualTo(pq.size());
         assertThat(PQ.peek()).isEqualTo(pq.peek());
 
@@ -299,7 +290,6 @@ public class BinaryHeapQuickRemovalsTest {
         assertThat(PQ.peek()).isEqualTo(pq.peek());
         assertThat(PQ.size()).isEqualTo(pq.size());
         assertThat(pq.isMinHeap(0)).isTrue();
-        ;
       }
     }
   }

--- a/src/test/java/com/williamfiset/algorithms/datastructures/priorityqueue/BinaryHeapTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/priorityqueue/BinaryHeapTest.java
@@ -1,6 +1,6 @@
 package com.williamfiset.algorithms.datastructures.priorityqueue;
 
-import static org.junit.Assert.*;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -19,10 +19,10 @@ public class BinaryHeapTest {
   @Test
   public void testEmpty() {
     BinaryHeap<Integer> q = new BinaryHeap<>();
-    assertEquals(q.size(), 0);
-    assertTrue(q.isEmpty());
-    assertEquals(q.poll(), null);
-    assertEquals(q.peek(), null);
+    assertThat(q.size()).isEqualTo(0);
+    assertThat(q.isEmpty()).isTrue();
+    assertThat(q.poll()).isNull();
+    assertThat(q.peek()).isNull();
   }
 
   @Test
@@ -33,13 +33,13 @@ public class BinaryHeapTest {
 
     // Try manually creating heap
     for (int n : nums) q.add(n);
-    for (int i = 1; i <= 9; i++) assertTrue(i == q.poll());
+    for (int i = 1; i <= 9; i++) assertThat(q.poll()).isEqualTo(i);
 
     q.clear();
 
     // Try heapify constructor
     q = new BinaryHeap<>(nums);
-    for (int i = 1; i <= 9; i++) assertTrue(i == q.poll());
+    for (int i = 1; i <= 9; i++) assertThat(q.poll()).isEqualTo(i);
   }
 
   @Test
@@ -53,9 +53,9 @@ public class BinaryHeapTest {
       PriorityQueue<Integer> pq2 = new PriorityQueue<>(i);
       for (int x : lst) pq2.add(x);
 
-      assertTrue(pq.isMinHeap(0));
+      assertThat(pq.isMinHeap(0)).isTrue();
       while (!pq2.isEmpty()) {
-        assertEquals(pq.poll(), pq2.poll());
+        assertThat(pq.poll()).isEqualTo(pq2.poll());
       }
     }
   }
@@ -67,8 +67,8 @@ public class BinaryHeapTest {
     String[] strs = {"aa", "bb", "cc", "dd", "ee"};
     q = new BinaryHeap<>(strs);
     q.clear();
-    assertEquals(q.size(), 0);
-    assertTrue(q.isEmpty());
+    assertThat(q.size()).isEqualTo(0);
+    assertThat(q.isEmpty()).isTrue();
   }
 
   @Test
@@ -77,15 +77,15 @@ public class BinaryHeapTest {
     String[] strs = {"aa", "bb", "cc", "dd", "ee"};
     BinaryHeap<String> q = new BinaryHeap<>(strs);
     q.remove("aa");
-    assertFalse(q.contains("aa"));
+    assertThat(q.contains("aa")).isFalse();
     q.remove("bb");
-    assertFalse(q.contains("bb"));
+    assertThat(q.contains("bb")).isFalse();
     q.remove("cc");
-    assertFalse(q.contains("cc"));
+    assertThat(q.contains("cc")).isFalse();
     q.remove("dd");
-    assertFalse(q.contains("dd"));
+    assertThat(q.contains("dd")).isFalse();
     q.clear();
-    assertFalse(q.contains("ee"));
+    assertThat(q.contains("ee")).isFalse();
   }
 
   @Test
@@ -104,35 +104,35 @@ public class BinaryHeapTest {
       for (int j = 0; j < randNums.size(); j++) {
 
         int randVal = randNums.get(j);
-        assertEquals(pq.contains(randVal), PQ.contains(randVal));
+        assertThat(pq.contains(randVal)).isEqualTo(PQ.contains(randVal));
         pq.remove(randVal);
         PQ.remove(randVal);
-        assertEquals(pq.contains(randVal), PQ.contains(randVal));
+        assertThat(pq.contains(randVal)).isEqualTo(PQ.contains(randVal));
       }
     }
   }
 
   public void sequentialRemoving(Integer[] in, Integer[] removeOrder) {
 
-    assertEquals(in.length, removeOrder.length);
+    assertThat(in.length).isEqualTo(removeOrder.length);
 
     BinaryHeap<Integer> pq = new BinaryHeap<>(in);
     PriorityQueue<Integer> PQ = new PriorityQueue<>();
     for (int value : in) PQ.offer(value);
 
-    assertTrue(pq.isMinHeap(0));
+    assertThat(pq.isMinHeap(0)).isTrue();
 
     for (int i = 0; i < removeOrder.length; i++) {
 
       int elem = removeOrder[i];
 
-      assertTrue(pq.peek() == PQ.peek());
-      assertEquals(pq.remove(elem), PQ.remove(elem));
-      assertTrue(pq.size() == PQ.size());
-      assertTrue(pq.isMinHeap(0));
+      assertThat(pq.peek()).isEqualTo(PQ.peek());
+      assertThat(pq.remove(elem)).isEqualTo(PQ.remove(elem));
+      assertThat(pq.size()).isEqualTo(PQ.size());
+      assertThat(pq.isMinHeap(0)).isTrue();
     }
 
-    assertTrue(pq.isEmpty());
+    assertThat(pq.isEmpty()).isTrue();
   }
 
   @Test
@@ -165,17 +165,17 @@ public class BinaryHeapTest {
     Integer[] in = new Integer[] {2, 7, 2, 11, 7, 13, 2};
     BinaryHeap<Integer> pq = new BinaryHeap<>(in);
 
-    assertTrue(pq.peek() == 2);
+    assertThat(pq.peek()).isEqualTo(2);
     pq.add(3);
 
-    assertTrue(pq.poll() == 2);
-    assertTrue(pq.poll() == 2);
-    assertTrue(pq.poll() == 2);
-    assertTrue(pq.poll() == 3);
-    assertTrue(pq.poll() == 7);
-    assertTrue(pq.poll() == 7);
-    assertTrue(pq.poll() == 11);
-    assertTrue(pq.poll() == 13);
+    assertThat(pq.poll()).isEqualTo(2);
+    assertThat(pq.poll()).isEqualTo(2);
+    assertThat(pq.poll()).isEqualTo( 2);
+    assertThat(pq.poll()).isEqualTo(3);
+    assertThat(pq.poll()).isEqualTo(7);
+    assertThat(pq.poll()).isEqualTo(7);
+    assertThat(pq.poll()).isEqualTo( 11);
+    assertThat(pq.poll()).isEqualTo(13);
   }
 
   @Test
@@ -196,18 +196,18 @@ public class BinaryHeapTest {
 
       while (!pq1.isEmpty()) {
 
-        assertTrue(pq2.isMinHeap(0));
-        assertEquals(pq1.size(), pq2.size());
-        assertEquals(pq1.peek(), pq2.peek());
-        assertEquals(pq1.contains(pq1.peek()), pq2.contains(pq2.peek()));
+        assertThat(pq2.isMinHeap(0)).isTrue();
+        assertThat(pq1.size()).isEqualTo(pq2.size());
+        assertThat(pq1.peek()).isEqualTo(pq2.peek());
+        assertThat(pq1.contains(pq1.peek())).isEqualTo(pq2.contains(pq2.peek()));
 
         Integer v1 = pq1.poll();
         Integer v2 = pq2.poll();
 
-        assertEquals(v1, v2);
-        assertEquals(pq1.peek(), pq2.peek());
-        assertEquals(pq1.size(), pq2.size());
-        assertTrue(pq2.isMinHeap(0));
+        assertThat(v1).isEqualTo(v2);
+        assertThat(pq1.peek()).isEqualTo(pq2.peek());
+        assertThat(pq1.size()).isEqualTo(pq2.size());
+        assertThat(pq2.isMinHeap(0));
       }
     }
   }
@@ -235,14 +235,14 @@ public class BinaryHeapTest {
 
         int removeNum = randNums.get(index++);
 
-        assertTrue(pq2.isMinHeap(0));
-        assertEquals(pq1.size(), pq2.size());
-        assertEquals(pq1.peek(), pq2.peek());
+        assertThat(pq2.isMinHeap(0)).isTrue();
+        assertThat(pq1.size()).isEqualTo(pq2.size());
+        assertThat(pq1.peek()).isEqualTo(pq2.peek());
         pq1.remove(removeNum);
         pq2.remove(removeNum);
-        assertEquals(pq1.peek(), pq2.peek());
-        assertEquals(pq1.size(), pq2.size());
-        assertTrue(pq2.isMinHeap(0));
+        assertThat(pq1.peek()).isEqualTo(pq2.peek());
+        assertThat(pq1.size()).isEqualTo(pq2.size());
+        assertThat(pq2.isMinHeap(0)).isTrue();
       }
     }
   }
@@ -279,16 +279,16 @@ public class BinaryHeapTest {
 
         int removeNum = nums.get(i);
 
-        assertTrue(pq.isMinHeap(0));
-        assertEquals(PQ.size(), pq.size());
-        assertEquals(PQ.peek(), pq.peek());
+        assertThat(pq.isMinHeap(0)).isTrue();
+        assertThat(PQ.size()).isEqualTo(pq.size());
+        assertThat(PQ.peek()).isEqualTo(pq.peek());
 
         PQ.remove(removeNum);
         pq.remove(removeNum);
 
-        assertEquals(PQ.peek(), pq.peek());
-        assertEquals(PQ.size(), pq.size());
-        assertTrue(pq.isMinHeap(0));
+        assertThat(PQ.peek()).isEqualTo(pq.peek());
+        assertThat(PQ.size()).isEqualTo(pq.size());
+        assertThat(pq.isMinHeap(0)).isTrue();
       }
     }
   }

--- a/src/test/java/com/williamfiset/algorithms/datastructures/priorityqueue/BinaryHeapTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/priorityqueue/BinaryHeapTest.java
@@ -174,7 +174,7 @@ public class BinaryHeapTest {
     assertThat(pq.poll()).isEqualTo(3);
     assertThat(pq.poll()).isEqualTo(7);
     assertThat(pq.poll()).isEqualTo(7);
-    assertThat(pq.poll()).isEqualTo( 11);
+    assertThat(pq.poll()).isEqualTo(11);
     assertThat(pq.poll()).isEqualTo(13);
   }
 

--- a/src/test/java/com/williamfiset/algorithms/datastructures/priorityqueue/BinaryHeapTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/priorityqueue/BinaryHeapTest.java
@@ -170,7 +170,7 @@ public class BinaryHeapTest {
 
     assertThat(pq.poll()).isEqualTo(2);
     assertThat(pq.poll()).isEqualTo(2);
-    assertThat(pq.poll()).isEqualTo( 2);
+    assertThat(pq.poll()).isEqualTo(2);
     assertThat(pq.poll()).isEqualTo(3);
     assertThat(pq.poll()).isEqualTo(7);
     assertThat(pq.poll()).isEqualTo(7);

--- a/src/test/java/com/williamfiset/algorithms/datastructures/priorityqueue/MinDHeapTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/priorityqueue/MinDHeapTest.java
@@ -1,6 +1,6 @@
 package com.williamfiset.algorithms.datastructures.priorityqueue;
 
-import static org.junit.Assert.*;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -20,10 +20,10 @@ public class MinDHeapTest {
   @Test
   public void testEmpty() {
     MinDHeap<Integer> q = new MinDHeap<>(4, 0);
-    assertEquals(q.size(), 0);
-    assertTrue(q.isEmpty());
-    assertEquals(q.poll(), null);
-    assertEquals(q.peek(), null);
+    assertThat(q.size()).isEqualTo(0);
+    assertThat(q.isEmpty()).isTrue();
+    assertThat(q.poll()).isNull();
+    assertThat(q.peek()).isNull();
   }
 
   @Test
@@ -34,7 +34,7 @@ public class MinDHeapTest {
 
     // Try manually creating heap
     for (int n : nums) q.add(n);
-    for (int i = 1; i <= 9; i++) assertTrue(i == q.poll());
+    for (int i = 1; i <= 9; i++) assertThat(q.poll()).isEqualTo(i);
   }
 
   @Test
@@ -50,7 +50,7 @@ public class MinDHeapTest {
         pq2.add(x);
         pq.add(x);
       }
-      while (!pq2.isEmpty()) assertEquals(pq.poll(), pq2.poll());
+      while (!pq2.isEmpty()) assertThat(pq.poll()).isEqualTo(pq2.poll());
     }
   }
 
@@ -78,14 +78,14 @@ public class MinDHeapTest {
           pq.add(e);
           pq2.add(e);
         } else if (p1 < r && r <= p2) {
-          if (!pq2.isEmpty()) assertEquals(pq.poll(), pq2.poll());
+          if (!pq2.isEmpty()) assertThat(pq.poll()).isEqualTo(pq2.poll());
         } else {
           pq.clear();
           pq2.clear();
         }
       }
 
-      assertEquals(pq.peek(), pq2.peek());
+      assertThat(pq.peek()).isEqualTo(pq2.peek());
     }
   }
 
@@ -95,8 +95,8 @@ public class MinDHeapTest {
     MinDHeap<String> q = new MinDHeap<>(2, strs.length);
     for (String s : strs) q.add(s);
     q.clear();
-    assertEquals(q.size(), 0);
-    assertTrue(q.isEmpty());
+    assertThat(q.size()).isEqualTo(0);
+    assertThat(q.isEmpty()).isTrue();
   }
 
   /*
@@ -116,9 +116,9 @@ public class MinDHeapTest {
       for (int j = 0; j < randNums.size(); j++) {
 
         int randVal = randNums.get(j);
-        assertEquals( pq.contains(randVal), PQ.contains(randVal) );
+        assertThat( pq.contains(randVal)).isEqualTo(PQ.contains(randVal) );
         pq.remove(randVal); PQ.remove(randVal);
-        assertEquals( pq.contains(randVal), PQ.contains(randVal) );
+        assertThat( pq.contains(randVal)).isEqualTo(PQ.contains(randVal) );
 
       }
 
@@ -128,26 +128,26 @@ public class MinDHeapTest {
 
   public void sequentialRemoving(Integer[] in, Integer[] removeOrder) {
 
-    assertEquals(in.length, removeOrder.length);
+    assertThat(in.length, removeOrder.length);
 
     PQueue <Integer> pq = new PQueue<>(in);
     PriorityQueue <Integer> PQ = new PriorityQueue<>();
     for (int value : in) PQ.offer(value);
 
-    assertTrue(pq.isMinHeap(0));
+    assertThat(pq.isMinHeap(0)).isTrue();
 
     for (int i = 0; i < removeOrder.length; i++) {
 
       int elem = removeOrder[i];
 
-      assertTrue(pq.peek() == PQ.peek());
-      assertEquals( pq.remove(elem), PQ.remove(elem));
-      assertTrue(pq.size() == PQ.size());
-      assertTrue(pq.isMinHeap(0));
+      assertThat(pq.peek()).isEqualTo(PQ.peek());
+      assertThat( pq.remove(elem)).isEqualTo(PQ.remove(elem));
+      assertThat(pq.size()).isEqualTo(PQ.size());
+      assertThat(pq.isMinHeap(0)).isTrue();
 
     }
 
-    assertTrue(pq.isEmpty());
+    assertThat(pq.isEmpty()).isTrue();
 
   }
 
@@ -184,17 +184,17 @@ public class MinDHeapTest {
     MinDHeap<Integer> pq = new MinDHeap<>(3, in.length + 1);
 
     for (Integer x : in) pq.add(x);
-    assertTrue(pq.peek() == 2);
+    assertThat(pq.peek()).isEqualTo(2);
     pq.add(3);
 
-    assertTrue(pq.poll() == 2);
-    assertTrue(pq.poll() == 2);
-    assertTrue(pq.poll() == 2);
-    assertTrue(pq.poll() == 3);
-    assertTrue(pq.poll() == 7);
-    assertTrue(pq.poll() == 7);
-    assertTrue(pq.poll() == 11);
-    assertTrue(pq.poll() == 13);
+    assertThat(pq.poll()).isEqualTo(2);
+    assertThat(pq.poll()).isEqualTo(2);
+    assertThat(pq.poll()).isEqualTo(2);
+    assertThat(pq.poll()).isEqualTo(3);
+    assertThat(pq.poll()).isEqualTo(7);
+    assertThat(pq.poll()).isEqualTo(7);
+    assertThat(pq.poll()).isEqualTo(11);
+    assertThat(pq.poll()).isEqualTo(13);
   }
   /*
   @Test
@@ -215,18 +215,18 @@ public class MinDHeapTest {
 
       while( !pq1.isEmpty() ) {
 
-        assertTrue(pq2.isMinHeap(0));
-        assertEquals( pq1.size(), pq2.size() );
-        assertEquals( pq1.peek(), pq2.peek() );
-        assertEquals( pq1.contains(pq1.peek()), pq2.contains(pq2.peek()) );
+        assertThat(pq2.isMinHeap(0)).isTrue();
+        assertThat(pq1.size()).isEqualTo(pq2.size());
+        assertThat(pq1.peek()).isEqualTo(pq2.peek());
+        assertThat(pq1.contains(pq1.peek())).isEqualTo(pq2.contains(pq2.peek()));
 
         Integer v1 = pq1.poll();
         Integer v2 = pq2.poll();
 
-        assertEquals(v1, v2);
-        assertEquals( pq1.peek(), pq2.peek() );
-        assertEquals( pq1.size(), pq2.size() );
-        assertTrue(pq2.isMinHeap(0));
+        assertThat(v1).isEqualTo(v2);
+        assertThat(pq1.peek()).isEqualTo(pq2.peek());
+        assertThat(pq1.size()).isEqualTo(pq2.size());
+        assertThat(pq2.isMinHeap(0)).isTrue();
 
       }
 
@@ -257,13 +257,13 @@ public class MinDHeapTest {
 
         int removeNum = randNums.get(index++);
 
-        assertTrue(pq2.isMinHeap(0));
-        assertEquals( pq1.size(), pq2.size() );
-        assertEquals( pq1.peek(), pq2.peek() );
+        assertThat(pq2.isMinHeap(0)).isTrue();
+        assertThat( pq1.size()).isEqualTo(pq2.size());
+        assertThat( pq1.peek()).isEqualTo(pq2.peek());
         pq1.remove(removeNum); pq2.remove(removeNum);
-        assertEquals( pq1.peek(), pq2.peek() );
-        assertEquals( pq1.size(), pq2.size() );
-        assertTrue(pq2.isMinHeap(0));
+        assertThat( pq1.peek()).isEqualTo(pq2.peek());
+        assertThat( pq1.size()).isEqualTo(pq2.size());
+        assertThat(pq2.isMinHeap(0)).isTrue();
 
       }
 
@@ -303,16 +303,16 @@ public class MinDHeapTest {
 
         int removeNum = nums.get(i);
 
-        assertTrue(pq.isMinHeap(0));
-        assertEquals( PQ.size(), pq.size() );
-        assertEquals( PQ.peek(), pq.peek() );
+        assertThat(pq.isMinHeap(0)).isTrue();
+        assertThat( PQ.size()).isEqualTo(pq.size());
+        assertThat( PQ.peek().isEqualTo(pq.peek());
 
         PQ.remove(removeNum);
         pq.remove(removeNum);
 
-        assertEquals( PQ.peek(), pq.peek() );
-        assertEquals( PQ.size(), pq.size() );
-        assertTrue(pq.isMinHeap(0));
+        assertThat( PQ.peek().isEqualTo(pq.peek());
+        assertThat( PQ.size().isEqualTo(pq.size());
+        assertThat(pq.isMinHeap(0)).isTrue();
 
       }
 

--- a/src/test/java/com/williamfiset/algorithms/datastructures/queue/IntQueueTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/queue/IntQueueTest.java
@@ -1,6 +1,6 @@
 package com.williamfiset.algorithms.datastructures.queue;
 
-import static org.junit.Assert.*;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.util.*;
 import org.junit.Before;
@@ -14,8 +14,8 @@ public class IntQueueTest {
   @Test
   public void testEmptyQueue() {
     IntQueue queue = new IntQueue(0);
-    assertTrue(queue.isEmpty());
-    assertEquals(queue.size(), 0);
+    assertThat(queue.isEmpty());
+    assertThat(queue.size()).isEqualTo(0);
   }
 
   // Doesn't apply to this implementation because of wrap
@@ -36,73 +36,73 @@ public class IntQueueTest {
   public void testofferOneElement() {
     IntQueue queue = new IntQueue(1);
     queue.offer(77);
-    assertEquals(queue.size(), 1);
+    assertThat(queue.size()).isEqualTo(1);
   }
 
   @Test
   public void testAll() {
     int n = 5;
     IntQueue queue = new IntQueue(10);
-    assertTrue(queue.isEmpty());
+    assertThat(queue.isEmpty()).isTrue();
     for (int i = 1; i <= n; i++) {
       queue.offer(i);
-      assertFalse(queue.isEmpty());
+      assertThat(queue.isEmpty()).isFalse();
     }
     for (int i = 1; i <= n; i++) {
-      assertEquals(i, (int) queue.peek());
-      assertEquals(i, (int) queue.poll());
-      assertEquals(queue.size(), n - i);
+      assertThat((int) queue.peek()).isEqualTo(i);
+      assertThat((int) queue.poll()).isEqualTo(i);
+      assertThat(queue.size()).isEqualTo(n - i);
     }
-    assertTrue(queue.isEmpty());
+    assertThat(queue.isEmpty()).isTrue();
     n = 8;
     for (int i = 1; i <= n; i++) {
       queue.offer(i);
-      assertFalse(queue.isEmpty());
+      assertThat(queue.isEmpty()).isFalse();
     }
     for (int i = 1; i <= n; i++) {
-      assertEquals(i, (int) queue.peek());
-      assertEquals(i, (int) queue.poll());
-      assertEquals(queue.size(), n - i);
+      assertThat((int) queue.peek()).isEqualTo(i);
+      assertThat((int) queue.poll()).isEqualTo(i);
+      assertThat(queue.size()).isEqualTo(n - i);
     }
-    assertTrue(queue.isEmpty());
+    assertThat(queue.isEmpty()).isTrue();
     n = 9;
     for (int i = 1; i <= n; i++) {
       queue.offer(i);
-      assertFalse(queue.isEmpty());
+      assertThat(queue.isEmpty()).isFalse();
     }
     for (int i = 1; i <= n; i++) {
-      assertEquals(i, (int) queue.peek());
-      assertEquals(i, (int) queue.poll());
-      assertEquals(queue.size(), n - i);
+      assertThat((int) queue.peek()).isEqualTo(i);
+      assertThat((int) queue.poll()).isEqualTo(i);
+      assertThat(queue.size()).isEqualTo(n - i);
     }
-    assertTrue(queue.isEmpty());
+    assertThat(queue.isEmpty()).isTrue();
     n = 10;
     for (int i = 1; i <= n; i++) {
       queue.offer(i);
-      assertFalse(queue.isEmpty());
+      assertThat(queue.isEmpty()).isFalse();
     }
     for (int i = 1; i <= n; i++) {
-      assertEquals(i, (int) queue.peek());
-      assertEquals(i, (int) queue.poll());
-      assertEquals(queue.size(), n - i);
+      assertThat((int) queue.peek()).isEqualTo(i);
+      assertThat((int) queue.poll()).isEqualTo(i);
+      assertThat(queue.size()).isEqualTo(n - i);
     }
-    assertTrue(queue.isEmpty());
+    assertThat(queue.isEmpty()).isTrue();
   }
 
   @Test
   public void testPeekOneElement() {
     IntQueue queue = new IntQueue(1);
     queue.offer(77);
-    assertTrue(queue.peek() == 77);
-    assertEquals(queue.size(), 1);
+    assertThat(queue.peek()).isEqualTo(77);
+    assertThat(queue.size()).isEqualTo(1);
   }
 
   @Test
   public void testpollOneElement() {
     IntQueue queue = new IntQueue(1);
     queue.offer(77);
-    assertTrue(queue.poll() == 77);
-    assertEquals(queue.size(), 0);
+    assertThat(queue.poll()).isEqualTo(77);
+    assertThat(queue.size()).isEqualTo(0);
   }
 
   @Test
@@ -113,8 +113,8 @@ public class IntQueueTest {
       IntQueue intQ = new IntQueue(qSize);
       ArrayDeque<Integer> javaQ = new ArrayDeque<>(qSize);
 
-      assertEquals(javaQ.isEmpty(), intQ.isEmpty());
-      assertEquals(javaQ.size(), intQ.size());
+      assertThat(javaQ.isEmpty()).isEqualTo(intQ.isEmpty());
+      assertThat(javaQ.size()).isEqualTo(intQ.size());
 
       for (int operations = 0; operations < 5000; operations++) {
 
@@ -128,12 +128,12 @@ public class IntQueueTest {
           }
         } else {
           if (!javaQ.isEmpty()) {
-            assertEquals((int) javaQ.poll(), (int) intQ.poll());
+            assertThat((int) javaQ.poll()).isEqualTo((int) intQ.poll());
           }
         }
 
-        assertEquals(javaQ.isEmpty(), intQ.isEmpty());
-        assertEquals(javaQ.size(), intQ.size());
+        assertThat(javaQ.isEmpty()).isEqualTo(intQ.isEmpty());
+        assertThat(javaQ.size()).isEqualTo(intQ.size());
       }
     }
   }

--- a/src/test/java/com/williamfiset/algorithms/datastructures/queue/IntQueueTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/queue/IntQueueTest.java
@@ -14,7 +14,7 @@ public class IntQueueTest {
   @Test
   public void testEmptyQueue() {
     IntQueue queue = new IntQueue(0);
-    assertThat(queue.isEmpty());
+    assertThat(queue.isEmpty()).isTrue();
     assertThat(queue.size()).isEqualTo(0);
   }
 

--- a/src/test/java/com/williamfiset/algorithms/datastructures/queue/QueueTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/queue/QueueTest.java
@@ -1,6 +1,6 @@
 package com.williamfiset.algorithms.datastructures.queue;
 
-import static org.junit.Assert.*;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -21,22 +21,22 @@ public class QueueTest {
   @Test
   public void testEmptyQueue() {
     for (Queue queue : queues) {
-      assertTrue(queue.isEmpty());
-      assertEquals(queue.size(), 0);
+      assertThat(queue.isEmpty()).isTrue();
+      assertThat(queue.size()).isEqualTo(0);
     }
   }
 
-  @Test
+  @Test(expected = Exception.class)
   public void testPollOnEmpty() {
     for (Queue queue : queues) {
-      assertThrows(Exception.class, queue::poll);
+      queue.poll();
     }
   }
 
-  @Test
+  @Test(expected = Exception.class)
   public void testPeekOnEmpty() {
     for (Queue queue : queues) {
-      assertThrows(Exception.class, queue::peek);
+      queue.peek();
     }
   }
 
@@ -44,7 +44,7 @@ public class QueueTest {
   public void testOffer() {
     for (Queue<Integer> queue : queues) {
       queue.offer(2);
-      assertEquals(queue.size(), 1);
+      assertThat(queue.size()).isEqualTo(1);
     }
   }
 
@@ -52,8 +52,8 @@ public class QueueTest {
   public void testPeek() {
     for (Queue<Integer> queue : queues) {
       queue.offer(2);
-      assertEquals(2, (int) queue.peek());
-      assertEquals(queue.size(), 1);
+      assertThat((int) queue.peek()).isEqualTo(2);
+      assertThat(queue.size()).isEqualTo(1);
     }
   }
 
@@ -61,28 +61,28 @@ public class QueueTest {
   public void testPoll() {
     for (Queue<Integer> queue : queues) {
       queue.offer(2);
-      assertEquals(2, (int) queue.poll());
-      assertEquals(queue.size(), 0);
+      assertThat((int) queue.poll()).isEqualTo(2);
+      assertThat(queue.size()).isEqualTo(0);
     }
   }
 
   @Test
   public void testExhaustively() {
     for (Queue<Integer> queue : queues) {
-      assertTrue(queue.isEmpty());
+      assertThat(queue.isEmpty()).isTrue();
       queue.offer(1);
-      assertFalse(queue.isEmpty());
+      assertThat(queue.isEmpty()).isFalse();
       queue.offer(2);
-      assertEquals(queue.size(), 2);
-      assertEquals(1, (int) queue.peek());
-      assertEquals(queue.size(), 2);
-      assertEquals(1, (int) queue.poll());
-      assertEquals(queue.size(), 1);
-      assertEquals(2, (int) queue.peek());
-      assertEquals(queue.size(), 1);
-      assertEquals(2, (int) queue.poll());
-      assertEquals(queue.size(), 0);
-      assertTrue(queue.isEmpty());
+      assertThat(queue.size()).isEqualTo(2);
+      assertThat((int) queue.peek()).isEqualTo(1);
+      assertThat(queue.size()).isEqualTo(2);
+      assertThat((int) queue.poll()).isEqualTo(1);
+      assertThat(queue.size()).isEqualTo(1);
+      assertThat((int) queue.peek()).isEqualTo(2);
+      assertThat(queue.size()).isEqualTo(1);
+      assertThat((int) queue.poll()).isEqualTo(2);
+      assertThat(queue.size()).isEqualTo(0);
+      assertThat(queue.isEmpty()).isTrue();
     }
   }
 }

--- a/src/test/java/com/williamfiset/algorithms/datastructures/segmenttree/RangeQueryPointUpdateSegmentTreeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/segmenttree/RangeQueryPointUpdateSegmentTreeTest.java
@@ -5,7 +5,6 @@
 package com.williamfiset.algorithms.datastructures.segmenttree;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.*;
 
 import com.williamfiset.algorithms.utils.TestUtils;
 import org.junit.Before;

--- a/src/test/java/com/williamfiset/algorithms/datastructures/segmenttree/SegmentTreeWithPointersTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/segmenttree/SegmentTreeWithPointersTest.java
@@ -3,7 +3,6 @@
 package com.williamfiset.algorithms.datastructures.segmenttree;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.*;
 
 import com.williamfiset.algorithms.utils.TestUtils;
 import org.junit.Before;

--- a/src/test/java/com/williamfiset/algorithms/datastructures/set/HSetTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/set/HSetTest.java
@@ -58,7 +58,7 @@ public class HSetTest {
     hs.add(-5);
     assertThat(hs.size()).isEqualTo(1);
     hs.remove(-5);
-    assertThat(hs.size()).isEqualTo( 0);
+    assertThat(hs.size()).isEqualTo(0);
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/set/HSetTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/set/HSetTest.java
@@ -1,6 +1,6 @@
 package com.williamfiset.algorithms.datastructures.set;
 
-import static org.junit.Assert.*;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -48,17 +48,17 @@ public class HSetTest {
   @Test
   public void testAddRemove() {
     hs.add(5);
-    assertEquals(hs.size(), 1);
+    assertThat(hs.size()).isEqualTo(1);
     hs.remove(5);
-    assertEquals(hs.size(), 0);
+    assertThat(hs.size()).isEqualTo(0);
     hs.add(0);
-    assertEquals(hs.size(), 1);
+    assertThat(hs.size()).isEqualTo(1);
     hs.remove(0);
-    assertEquals(hs.size(), 0);
+    assertThat(hs.size()).isEqualTo(0);
     hs.add(-5);
-    assertEquals(hs.size(), 1);
+    assertThat(hs.size()).isEqualTo(1);
     hs.remove(-5);
-    assertEquals(hs.size(), 0);
+    assertThat(hs.size()).isEqualTo( 0);
   }
 
   @Test
@@ -73,7 +73,7 @@ public class HSetTest {
       for (int i = 0; i < TEST_SZ; i++) {
 
         int num = nums.get(i);
-        // assertEquals( hs.add(num), s.add(num) );
+        // assertThat( hs.add(num)).isEqualTo(s.add(num));
         hs.add(num);
         s.add(num);
 
@@ -81,7 +81,7 @@ public class HSetTest {
         for (Integer n : s) hs.contains(n);
         for (Integer n : hs) s.contains(n);
 
-        assertEquals(s.size(), hs.size());
+        assertThat(s.size()).isEqualTo(hs.size());
       }
     }
   }
@@ -103,7 +103,7 @@ public class HSetTest {
 
         int num = nums.get(i);
         ConstObj obj = new ConstObj(java.util.Objects.hash(num), num);
-        // assertEquals( hs.add(num), s.add(num) );
+        // assertThat( hs.add(num)).isEqualTo(s.add(num));
         hs.add(obj);
         s.add(obj);
 
@@ -111,7 +111,7 @@ public class HSetTest {
         for (ConstObj n : s) hs.contains(n);
         for (ConstObj n : hs) s.contains(n);
 
-        assertEquals(s.size(), hs.size());
+        assertThat(s.size()).isEqualTo(hs.size());
       }
     }
   }
@@ -125,13 +125,13 @@ public class HSetTest {
     HSet<ConstObj> s = new HSet<ConstObj>();
 
     s.add(ch1);
-    assertEquals(1, s.size());
+    assertThat(s.size()).isEqualTo(1);
     s.remove(ch1);
-    assertEquals(0, s.size());
+    assertThat(s.size()).isEqualTo(0);
     s.add(ch2);
-    assertEquals(1, s.size());
+    assertThat(s.size()).isEqualTo(1);
     s.remove(ch2);
-    assertEquals(0, s.size());
+    assertThat(s.size()).isEqualTo(0);
   }
 
   // Generate a list of random numbers

--- a/src/test/java/com/williamfiset/algorithms/datastructures/set/HSetTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/set/HSetTest.java
@@ -73,7 +73,7 @@ public class HSetTest {
       for (int i = 0; i < TEST_SZ; i++) {
 
         int num = nums.get(i);
-        // assertThat( hs.add(num)).isEqualTo(s.add(num));
+        // assertThat(hs.add(num)).isEqualTo(s.add(num));
         hs.add(num);
         s.add(num);
 
@@ -103,7 +103,7 @@ public class HSetTest {
 
         int num = nums.get(i);
         ConstObj obj = new ConstObj(java.util.Objects.hash(num), num);
-        // assertThat( hs.add(num)).isEqualTo(s.add(num));
+        // assertThat(hs.add(num)).isEqualTo(s.add(num));
         hs.add(obj);
         s.add(obj);
 

--- a/src/test/java/com/williamfiset/algorithms/datastructures/stack/StackTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/stack/StackTest.java
@@ -1,6 +1,6 @@
 package com.williamfiset.algorithms.datastructures.stack;
 
-import static org.junit.Assert.*;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -21,22 +21,22 @@ public class StackTest {
   @Test
   public void testEmptyStack() {
     for (Stack stack : stacks) {
-      assertTrue(stack.isEmpty());
-      assertEquals(stack.size(), 0);
+      assertThat(stack.isEmpty()).isTrue();
+      assertThat(stack.size()).isEqualTo(0);
     }
   }
 
-  @Test
+  @Test(expected = Exception.class)
   public void testPopOnEmpty() {
     for (Stack stack : stacks) {
-      assertThrows(Exception.class, stack::pop);
+      stack.pop();
     }
   }
 
-  @Test
+  @Test(expected = Exception.class)
   public void testPeekOnEmpty() {
     for (Stack stack : stacks) {
-      assertThrows(Exception.class, stack::peek);
+      stack.peek();
     }
   }
 
@@ -44,7 +44,7 @@ public class StackTest {
   public void testPush() {
     for (Stack<Integer> stack : stacks) {
       stack.push(2);
-      assertEquals(stack.size(), 1);
+      assertThat(stack.size()).isEqualTo(1);
     }
   }
 
@@ -52,8 +52,8 @@ public class StackTest {
   public void testPeek() {
     for (Stack<Integer> stack : stacks) {
       stack.push(2);
-      assertEquals(2, (int) (Integer) stack.peek());
-      assertEquals(stack.size(), 1);
+      assertThat((int) (Integer) stack.peek()).isEqualTo(2);
+      assertThat(stack.size()).isEqualTo(1);
     }
   }
 
@@ -61,28 +61,28 @@ public class StackTest {
   public void testPop() {
     for (Stack<Integer> stack : stacks) {
       stack.push(2);
-      assertEquals(2, (int) stack.pop());
-      assertEquals(stack.size(), 0);
+      assertThat((int) stack.pop()).isEqualTo(2);
+      assertThat(stack.size()).isEqualTo(0);
     }
   }
 
   @Test
   public void testExhaustively() {
     for (Stack<Integer> stack : stacks) {
-      assertTrue(stack.isEmpty());
+      assertThat(stack.isEmpty()).isTrue();
       stack.push(1);
-      assertFalse(stack.isEmpty());
+      assertThat(stack.isEmpty()).isFalse();
       stack.push(2);
-      assertEquals(stack.size(), 2);
-      assertEquals(2, (int) stack.peek());
-      assertEquals(stack.size(), 2);
-      assertEquals(2, (int) stack.pop());
-      assertEquals(stack.size(), 1);
-      assertEquals(1, (int) stack.peek());
-      assertEquals(stack.size(), 1);
-      assertEquals(1, (int) stack.pop());
-      assertEquals(stack.size(), 0);
-      assertTrue(stack.isEmpty());
+      assertThat(stack.size()).isEqualTo(2);
+      assertThat((int) stack.peek()).isEqualTo(2);
+      assertThat(stack.size()).isEqualTo(2);
+      assertThat((int) stack.pop()).isEqualTo(2);
+      assertThat(stack.size()).isEqualTo(1);
+      assertThat((int) stack.peek()).isEqualTo(1);
+      assertThat(stack.size()).isEqualTo(1);
+      assertThat((int) stack.pop()).isEqualTo(1);
+      assertThat(stack.size()).isEqualTo(0);
+      assertThat(stack.isEmpty()).isTrue();
     }
   }
 }

--- a/src/test/java/com/williamfiset/algorithms/datastructures/suffixarray/SuffixArrayTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/suffixarray/SuffixArrayTest.java
@@ -1,6 +1,6 @@
 package com.williamfiset.algorithms.datastructures.suffixarray;
 
-import static org.junit.Assert.*;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.security.SecureRandom;
 import java.util.Random;
@@ -29,9 +29,9 @@ public class SuffixArrayTest {
     SuffixArray sa2 = new SuffixArrayMed(str);
     SuffixArray sa3 = new SuffixArrayFast(str);
 
-    assertEquals(str.length(), sa1.getSa().length);
-    assertEquals(str.length(), sa2.getSa().length);
-    assertEquals(str.length(), sa3.getSa().length);
+    assertThat(sa1.getSa().length).isEqualTo(str.length());
+    assertThat(sa2.getSa().length).isEqualTo(str.length());
+    assertThat(sa3.getSa().length).isEqualTo(str.length());
   }
 
   @Test
@@ -45,7 +45,7 @@ public class SuffixArrayTest {
 
     for (SuffixArray sa : suffixArrays) {
       for (int i = 0; i < sa.getSa().length; i++) {
-        assertEquals(0, sa.getLcpArray()[i]);
+        assertThat(sa.getLcpArray()[i]).isEqualTo(0);
       }
     }
   }
@@ -63,7 +63,7 @@ public class SuffixArrayTest {
 
     for (SuffixArray sa : suffixArrays) {
       for (int i = 0; i < sa.getSa().length; i++) {
-        assertEquals(i, sa.getLcpArray()[i]);
+        assertThat(sa.getLcpArray()[i]).isEqualTo(i);
       }
     }
   }
@@ -82,7 +82,7 @@ public class SuffixArrayTest {
 
     for (SuffixArray sa : suffixArrays) {
       for (int i = 0; i < sa.getSa().length; i++) {
-        assertEquals(lcpValues[i], sa.getLcpArray()[i]);
+        assertThat(lcpValues[i]).isEqualTo(sa.getLcpArray()[i]);
       }
     }
   }
@@ -100,7 +100,7 @@ public class SuffixArrayTest {
 
     for (SuffixArray sa : suffixArrays) {
       for (int i = 0; i < sa.getSa().length; i++) {
-        assertEquals(lcpValues[i], sa.getLcpArray()[i]);
+        assertThat(lcpValues[i]).isEqualTo(sa.getLcpArray()[i]);
       }
     }
   }
@@ -121,7 +121,7 @@ public class SuffixArrayTest {
         SuffixArray s1 = suffixArrays[i];
         SuffixArray s2 = suffixArrays[j];
         for (int k = 0; k < s1.getSa().length; k++) {
-          assertEquals(s1.getSa()[k], s2.getSa()[k]);
+          assertThat(s1.getSa()[k]).isEqualTo(s2.getSa()[k]);
         }
       }
     }

--- a/src/test/java/com/williamfiset/algorithms/datastructures/trie/TrieTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/trie/TrieTest.java
@@ -315,7 +315,7 @@ public class TrieTest {
     assertThat(t.contains("$A")).isTrue();
     assertThat(t.contains("$B")).isTrue();
     assertThat(t.contains("$C")).isTrue();
-    assertThat(t.delete("$A")).isFalse();
+    assertThat(t.delete("$A")).isTrue();
     assertThat(t.delete("$B")).isFalse();
     assertThat(t.delete("$C")).isFalse();
 

--- a/src/test/java/com/williamfiset/algorithms/datastructures/trie/TrieTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/trie/TrieTest.java
@@ -1,6 +1,6 @@
 package com.williamfiset.algorithms.datastructures.trie;
 
-import static org.junit.Assert.*;
+import static com.google.common.truth.Truth.assertThat;
 
 import org.junit.*;
 
@@ -53,11 +53,11 @@ public class TrieTest {
     // a valid string to be inserted into the trie (although it
     // would be easy to account for)
     t1.insert("");
-    assertFalse(t1.contains(""));
+    assertThat(t1.contains("")).isFalse();
     t1.insert("");
-    assertFalse(t1.contains(""));
+    assertThat(t1.contains("")).isFalse();
     t1.insert("");
-    assertFalse(t1.contains(""));
+    assertThat(t1.contains("")).isFalse();
 
     Trie t2 = new Trie();
     t2.insert("aaaaa");
@@ -65,11 +65,11 @@ public class TrieTest {
     t2.insert("aaaaa");
     t2.insert("aaaaa");
     t2.insert("aaaaa");
-    assertTrue(t2.contains("aaaaa"));
-    assertTrue(t2.contains("aaaa"));
-    assertTrue(t2.contains("aaa"));
-    assertTrue(t2.contains("aa"));
-    assertTrue(t2.contains("a"));
+    assertThat(t2.contains("aaaaa")).isTrue();
+    assertThat(t2.contains("aaaa")).isTrue();
+    assertThat(t2.contains("aaa")).isTrue();
+    assertThat(t2.contains("aa")).isTrue();
+    assertThat(t2.contains("a")).isTrue();
 
     Trie t3 = new Trie();
 
@@ -86,18 +86,18 @@ public class TrieTest {
     t3.insert("B");
     t3.insert("B");
 
-    assertTrue(t3.contains("A"));
-    assertTrue(t3.contains("AH"));
-    assertTrue(t3.contains("A7"));
-    assertTrue(t3.contains("AE"));
-    assertTrue(t3.contains("AH7"));
-    assertTrue(t3.contains("7"));
-    assertTrue(t3.contains("B"));
+    assertThat(t3.contains("A")).isTrue();
+    assertThat(t3.contains("AH")).isTrue();
+    assertThat(t3.contains("A7")).isTrue();
+    assertThat(t3.contains("AE")).isTrue();
+    assertThat(t3.contains("AH7")).isTrue();
+    assertThat(t3.contains("7")).isTrue();
+    assertThat(t3.contains("B")).isTrue();
 
-    assertFalse(t3.contains("Ar"));
-    assertFalse(t3.contains("A8"));
-    assertFalse(t3.contains("AH6"));
-    assertFalse(t3.contains("C"));
+    assertThat(t3.contains("Ar")).isFalse();
+    assertThat(t3.contains("A8")).isFalse();
+    assertThat(t3.contains("AH6")).isFalse();
+    assertThat(t3.contains("C")).isFalse();
   }
 
   @Test
@@ -109,11 +109,11 @@ public class TrieTest {
     // a valid string to be inserted into the trie (although it
     // would be easy to account for)
     t1.insert("");
-    assertEquals(t1.count(""), 0);
+    assertThat(t1.count("")).isEqualTo(0);
     t1.insert("");
-    assertEquals(t1.count(""), 0);
+    assertThat(t1.count("")).isEqualTo(0);
     t1.insert("");
-    assertEquals(t1.count(""), 0);
+    assertThat(t1.count("")).isEqualTo(0);
 
     Trie t2 = new Trie();
     t2.insert("aaaaa");
@@ -121,11 +121,11 @@ public class TrieTest {
     t2.insert("aaaaa");
     t2.insert("aaaaa");
     t2.insert("aaaaa");
-    assertEquals(t2.count("aaaaa"), 5);
-    assertEquals(t2.count("aaaa"), 5);
-    assertEquals(t2.count("aaa"), 5);
-    assertEquals(t2.count("aa"), 5);
-    assertEquals(t2.count("a"), 5);
+    assertThat(t2.count("aaaaa")).isEqualTo(5);
+    assertThat(t2.count("aaaa")).isEqualTo(5);
+    assertThat(t2.count("aaa")).isEqualTo(5);
+    assertThat(t2.count("aa")).isEqualTo(5);
+    assertThat(t2.count("a")).isEqualTo(5);
 
     Trie t3 = new Trie();
 
@@ -144,55 +144,55 @@ public class TrieTest {
     t3.insert("B");
     t3.insert("B");
 
-    assertEquals(t3.count("A"), 6);
-    assertEquals(t3.count("AH"), 3);
-    assertEquals(t3.count("A7"), 1);
-    assertEquals(t3.count("AE"), 2);
-    assertEquals(t3.count("AH7"), 1);
-    assertEquals(t3.count("7"), 2);
-    assertEquals(t3.count("B"), 4);
-    assertEquals(t3.count("Ar"), 0);
-    assertEquals(t3.count("A8"), 0);
-    assertEquals(t3.count("AH6"), 0);
-    assertEquals(t3.count("C"), 0);
+    assertThat(t3.count("A")).isEqualTo(6);
+    assertThat(t3.count("AH")).isEqualTo(3);
+    assertThat(t3.count("A7")).isEqualTo(1);
+    assertThat(t3.count("AE")).isEqualTo(2);
+    assertThat(t3.count("AH7")).isEqualTo(1);
+    assertThat(t3.count("7")).isEqualTo(2);
+    assertThat(t3.count("B")).isEqualTo(4);
+    assertThat(t3.count("Ar")).isEqualTo(0);
+    assertThat(t3.count("A8")).isEqualTo(0);
+    assertThat(t3.count("AH6")).isEqualTo(0);
+    assertThat(t3.count("C")).isEqualTo(0);
   }
 
   @Test
   public void testInsert() {
 
     Trie t = new Trie();
-    assertFalse(t.insert("a"));
-    assertFalse(t.insert("b"));
-    assertFalse(t.insert("c"));
-    assertFalse(t.insert("d"));
-    assertFalse(t.insert("x"));
+    assertThat(t.insert("a")).isFalse();
+    assertThat(t.insert("b")).isFalse();
+    assertThat(t.insert("c")).isFalse();
+    assertThat(t.insert("d")).isFalse();
+    assertThat(t.insert("x")).isFalse();
 
-    assertTrue(t.insert("ab"));
-    assertTrue(t.insert("xkcd"));
-    assertTrue(t.insert("dogs"));
-    assertTrue(t.insert("bears"));
+    assertThat(t.insert("ab")).isTrue();
+    assertThat(t.insert("xkcd")).isTrue();
+    assertThat(t.insert("dogs")).isTrue();
+    assertThat(t.insert("bears")).isTrue();
 
-    assertFalse(t.insert("mo"));
-    assertTrue(t.insert("mooooose"));
+    assertThat(t.insert("mo")).isFalse();
+    assertThat(t.insert("mooooose")).isTrue();
 
     t.clear();
 
-    assertFalse(t.insert("aaaa", 4));
-    assertEquals(t.count("aaaa"), 4);
+    assertThat(t.insert("aaaa", 4)).isFalse();
+    assertThat(t.count("aaaa")).isEqualTo(4);
 
-    assertTrue(t.insert("aaa", 3));
-    assertEquals(t.count("a"), 7);
-    assertEquals(t.count("aa"), 7);
-    assertEquals(t.count("aaa"), 7);
-    assertEquals(t.count("aaaa"), 4);
-    assertEquals(t.count("aaaaa"), 0);
+    assertThat(t.insert("aaa", 3)).isTrue();
+    assertThat(t.count("a")).isEqualTo(7);
+    assertThat(t.count("aa")).isEqualTo(7);
+    assertThat(t.count("aaa")).isEqualTo(7);
+    assertThat(t.count("aaaa")).isEqualTo(4);
+    assertThat(t.count("aaaaa")).isEqualTo(0);
 
-    assertTrue(t.insert("a", 5));
-    assertEquals(t.count("a"), 12);
-    assertEquals(t.count("aa"), 7);
-    assertEquals(t.count("aaa"), 7);
-    assertEquals(t.count("aaaa"), 4);
-    assertEquals(t.count("aaaaa"), 0);
+    assertThat(t.insert("a", 5)).isTrue();
+    assertThat(t.count("a")).isEqualTo(12);
+    assertThat(t.count("aa")).isEqualTo(7);
+    assertThat(t.count("aaa")).isEqualTo(7);
+    assertThat(t.count("aaaa")).isEqualTo(4);
+    assertThat(t.count("aaaaa")).isEqualTo(0);
   }
 
   @Test
@@ -200,19 +200,19 @@ public class TrieTest {
 
     Trie t = new Trie();
 
-    assertFalse(t.insert("a"));
-    assertFalse(t.insert("b"));
-    assertFalse(t.insert("c"));
+    assertThat(t.insert("a")).isFalse();
+    assertThat(t.insert("b")).isFalse();
+    assertThat(t.insert("c")).isFalse();
 
-    assertTrue(t.contains("a"));
-    assertTrue(t.contains("b"));
-    assertTrue(t.contains("c"));
+    assertThat(t.contains("a")).isTrue();
+    assertThat(t.contains("b")).isTrue();
+    assertThat(t.contains("c")).isTrue();
 
     t.clear();
 
-    assertFalse(t.contains("a"));
-    assertFalse(t.contains("b"));
-    assertFalse(t.contains("c"));
+    assertThat(t.contains("a")).isFalse();
+    assertThat(t.contains("b")).isFalse();
+    assertThat(t.contains("c")).isFalse();
 
     t.insert("aaaa");
     t.insert("aaab");
@@ -220,17 +220,17 @@ public class TrieTest {
     t.insert("aaac");
     t.insert("aaacb");
 
-    assertTrue(t.contains("aaa"));
-    assertTrue(t.contains("aaacb"));
-    assertTrue(t.contains("aaab5"));
+    assertThat(t.contains("aaa")).isTrue();
+    assertThat(t.contains("aaacb")).isTrue();
+    assertThat(t.contains("aaab5")).isTrue();
 
     t.clear();
 
-    assertFalse(t.contains("aaaa"));
-    assertFalse(t.contains("aaab"));
-    assertFalse(t.contains("aaab5"));
-    assertFalse(t.contains("aaac"));
-    assertFalse(t.contains("aaacb"));
+    assertThat(t.contains("aaaa")).isFalse();
+    assertThat(t.contains("aaab")).isFalse();
+    assertThat(t.contains("aaab5")).isFalse();
+    assertThat(t.contains("aaac")).isFalse();
+    assertThat(t.contains("aaacb")).isFalse();
   }
 
   @Test
@@ -241,20 +241,20 @@ public class TrieTest {
     t.insert("AA");
     t.insert("A");
 
-    assertTrue(t.delete("AAC"));
-    assertFalse(t.contains("AAC"));
-    assertTrue(t.contains("AA"));
-    assertTrue(t.contains("A"));
+    assertThat(t.delete("AAC")).isTrue();
+    assertThat(t.contains("AAC")).isFalse();
+    assertThat(t.contains("AA")).isTrue();
+    assertThat(t.contains("A")).isTrue();
 
-    assertTrue(t.delete("AA"));
-    assertFalse(t.contains("AAC"));
-    assertFalse(t.contains("AA"));
-    assertTrue(t.contains("A"));
+    assertThat(t.delete("AA")).isTrue();
+    assertThat(t.contains("AAC")).isFalse();
+    assertThat(t.contains("AA")).isFalse();
+    assertThat(t.contains("A")).isTrue();
 
-    assertTrue(t.delete("A"));
-    assertFalse(t.contains("AAC"));
-    assertFalse(t.contains("AA"));
-    assertFalse(t.contains("A"));
+    assertThat(t.delete("A")).isTrue();
+    assertThat(t.contains("AAC")).isFalse();
+    assertThat(t.contains("AA")).isFalse();
+    assertThat(t.contains("A")).isFalse();
 
     t.clear();
 
@@ -262,29 +262,12 @@ public class TrieTest {
     t.insert("AA");
     t.insert("A");
 
-    assertTrue(t.delete("AA"));
-    assertTrue(t.delete("AA"));
+    assertThat(t.delete("AA")).isTrue();
+    assertThat(t.delete("AA")).isTrue();
 
-    assertFalse(t.contains("AAC"));
-    assertFalse(t.contains("AA"));
-    assertTrue(t.contains("A"));
-
-    t.clear();
-
-    t.insert("$A");
-    t.insert("$B");
-    t.insert("$C");
-
-    assertTrue(t.delete("$", 3));
-
-    assertFalse(t.delete("$"));
-    assertFalse(t.contains("$"));
-    assertFalse(t.contains("$A"));
-    assertFalse(t.contains("$B"));
-    assertFalse(t.contains("$C"));
-    assertFalse(t.delete("$A"));
-    assertFalse(t.delete("$B"));
-    assertFalse(t.delete("$C"));
+    assertThat(t.contains("AAC")).isFalse();
+    assertThat(t.contains("AA")).isFalse();
+    assertThat(t.contains("A")).isTrue();
 
     t.clear();
 
@@ -292,16 +275,16 @@ public class TrieTest {
     t.insert("$B");
     t.insert("$C");
 
-    assertTrue(t.delete("$", 2));
-    assertTrue(t.delete("$"));
+    assertThat(t.delete("$", 3)).isTrue();
 
-    assertFalse(t.contains("$"));
-    assertFalse(t.contains("$A"));
-    assertFalse(t.contains("$B"));
-    assertFalse(t.contains("$C"));
-    assertFalse(t.delete("$A"));
-    assertFalse(t.delete("$B"));
-    assertFalse(t.delete("$C"));
+    assertThat(t.delete("$")).isFalse();
+    assertThat(t.contains("$")).isFalse();
+    assertThat(t.contains("$A")).isFalse();
+    assertThat(t.contains("$B")).isFalse();
+    assertThat(t.contains("$C")).isFalse();
+    assertThat(t.delete("$A")).isFalse();
+    assertThat(t.delete("$B")).isFalse();
+    assertThat(t.delete("$C")).isFalse();
 
     t.clear();
 
@@ -309,22 +292,39 @@ public class TrieTest {
     t.insert("$B");
     t.insert("$C");
 
-    assertTrue(t.delete("$", 2));
+    assertThat(t.delete("$", 2)).isTrue();
+    assertThat(t.delete("$")).isTrue();
 
-    assertTrue(t.contains("$"));
-    assertTrue(t.contains("$A"));
-    assertTrue(t.contains("$B"));
-    assertTrue(t.contains("$C"));
-    assertTrue(t.delete("$A"));
-    assertFalse(t.delete("$B"));
-    assertFalse(t.delete("$C"));
+    assertThat(t.contains("$")).isFalse();
+    assertThat(t.contains("$A")).isFalse();
+    assertThat(t.contains("$B")).isFalse();
+    assertThat(t.contains("$C")).isFalse();
+    assertThat(t.delete("$A")).isFalse();
+    assertThat(t.delete("$B")).isFalse();
+    assertThat(t.delete("$C")).isFalse();
+
+    t.clear();
+
+    t.insert("$A");
+    t.insert("$B");
+    t.insert("$C");
+
+    assertThat(t.delete("$", 2)).isTrue();
+
+    assertThat(t.contains("$")).isTrue();
+    assertThat(t.contains("$A")).isTrue();
+    assertThat(t.contains("$B")).isTrue();
+    assertThat(t.contains("$C")).isTrue();
+    assertThat(t.delete("$A")).isFalse();
+    assertThat(t.delete("$B")).isFalse();
+    assertThat(t.delete("$C")).isFalse();
 
     t.clear();
 
     t.insert("CAT", 3);
     t.insert("DOG", 3);
 
-    assertFalse(t.delete("parrot", 50));
+    assertThat(t.delete("parrot", 50)).isFalse();
 
     t.clear();
 
@@ -332,26 +332,13 @@ public class TrieTest {
     t.insert("122", 2);
     t.insert("123", 3);
 
-    assertTrue(t.delete("12", 6));
-    assertFalse(t.delete("12"));
-    assertFalse(t.delete("1"));
-    assertFalse(t.contains("1234"));
-    assertFalse(t.contains("123"));
-    assertFalse(t.contains("12"));
-    assertFalse(t.contains("1"));
-
-    t.clear();
-
-    t.insert("1234");
-    t.insert("122", 2);
-    t.insert("123", 3);
-
-    t.delete("12", 999999);
-
-    assertFalse(t.contains("1234"));
-    assertFalse(t.contains("123"));
-    assertFalse(t.contains("12"));
-    assertFalse(t.contains("1"));
+    assertThat(t.delete("12", 6)).isTrue();
+    assertThat(t.delete("12")).isFalse();
+    assertThat(t.delete("1")).isFalse();
+    assertThat(t.contains("1234")).isFalse();
+    assertThat(t.contains("123")).isFalse();
+    assertThat(t.contains("12")).isFalse();
+    assertThat(t.contains("1")).isFalse();
 
     t.clear();
 
@@ -361,10 +348,10 @@ public class TrieTest {
 
     t.delete("12", 999999);
 
-    assertFalse(t.contains("1234"));
-    assertFalse(t.contains("123"));
-    assertFalse(t.contains("12"));
-    assertFalse(t.contains("1"));
+    assertThat(t.contains("1234")).isFalse();
+    assertThat(t.contains("123")).isFalse();
+    assertThat(t.contains("12")).isFalse();
+    assertThat(t.contains("1")).isFalse();
 
     t.clear();
 
@@ -372,33 +359,46 @@ public class TrieTest {
     t.insert("122", 2);
     t.insert("123", 3);
 
-    assertTrue(t.delete("1234"));
-    assertTrue(t.delete("123", 4));
-    assertTrue(t.delete("122", 2));
+    t.delete("12", 999999);
 
-    assertFalse(t.contains("1"));
-    assertFalse(t.contains("12"));
-    assertFalse(t.contains("122"));
-    assertFalse(t.contains("123"));
-    assertFalse(t.contains("1234"));
+    assertThat(t.contains("1234")).isFalse();
+    assertThat(t.contains("123")).isFalse();
+    assertThat(t.contains("12")).isFalse();
+    assertThat(t.contains("1")).isFalse();
+
+    t.clear();
+
+    t.insert("1234");
+    t.insert("122", 2);
+    t.insert("123", 3);
+
+    assertThat(t.delete("1234")).isTrue();
+    assertThat(t.delete("123", 4)).isTrue();
+    assertThat(t.delete("122", 2)).isTrue();
+
+    assertThat(t.contains("1")).isFalse();
+    assertThat(t.contains("12")).isFalse();
+    assertThat(t.contains("122")).isFalse();
+    assertThat(t.contains("123")).isFalse();
+    assertThat(t.contains("1234")).isFalse();
   }
 
   @Test
   public void testEdgeCases() {
 
     Trie t = new Trie();
-    assertEquals(t.count(""), 0);
-    assertEquals(t.count("\0"), 0);
-    assertEquals(t.count("\0\0"), 0);
-    assertEquals(t.count("\0\0\0"), 0);
+    assertThat(t.count("")).isEqualTo(0);
+    assertThat(t.count("\0")).isEqualTo(0);
+    assertThat(t.count("\0\0")).isEqualTo(0);
+    assertThat(t.count("\0\0\0")).isEqualTo(0);
 
-    for (char c = 0; c < 128; c++) assertEquals(t.count("" + c), 0);
+    for (char c = 0; c < 128; c++) assertThat(t.count("" + c)).isEqualTo(0);
 
-    assertFalse(t.contains(""));
-    assertFalse(t.contains("\0"));
-    assertFalse(t.contains("\0\0"));
-    assertFalse(t.contains("\0\0\0"));
+    assertThat(t.contains("")).isFalse();
+    assertThat(t.contains("\0")).isFalse();
+    assertThat(t.contains("\0\0")).isFalse();
+    assertThat(t.contains("\0\0\0")).isFalse();
 
-    for (char c = 0; c < 128; c++) assertFalse(t.contains("" + c));
+    for (char c = 0; c < 128; c++) assertThat(t.contains("" + c)).isFalse();
   }
 }

--- a/src/test/java/com/williamfiset/algorithms/datastructures/unionfind/UnionFindTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/unionfind/UnionFindTest.java
@@ -1,6 +1,7 @@
 package com.williamfiset.algorithms.datastructures.unionfind;
 
-import static org.junit.Assert.*;
+// import static org.junit.Assert.*;
+import static com.google.common.truth.Truth.assertThat;
 
 import org.junit.*;
 
@@ -10,108 +11,108 @@ public class UnionFindTest {
   public void testNumComponents() {
 
     UnionFind uf = new UnionFind(5);
-    assertEquals(uf.components(), 5);
+    assertThat(uf.components()).isEqualTo(5);
 
     uf.unify(0, 1);
-    assertEquals(uf.components(), 4);
+    assertThat(uf.components()).isEqualTo(4);
 
     uf.unify(1, 0);
-    assertEquals(uf.components(), 4);
+    assertThat(uf.components()).isEqualTo(4);
 
     uf.unify(1, 2);
-    assertEquals(uf.components(), 3);
+    assertThat(uf.components()).isEqualTo(3);
 
     uf.unify(0, 2);
-    assertEquals(uf.components(), 3);
+    assertThat(uf.components()).isEqualTo(3);
 
     uf.unify(2, 1);
-    assertEquals(uf.components(), 3);
+    assertThat(uf.components()).isEqualTo(3);
 
     uf.unify(3, 4);
-    assertEquals(uf.components(), 2);
+    assertThat(uf.components()).isEqualTo(2);
 
     uf.unify(4, 3);
-    assertEquals(uf.components(), 2);
+    assertThat(uf.components()).isEqualTo(2);
 
     uf.unify(1, 3);
-    assertEquals(uf.components(), 1);
+    assertThat(uf.components()).isEqualTo(1);
 
     uf.unify(4, 0);
-    assertEquals(uf.components(), 1);
+    assertThat(uf.components()).isEqualTo(1);
   }
 
   @Test
   public void testComponentSize() {
 
     UnionFind uf = new UnionFind(5);
-    assertEquals(uf.componentSize(0), 1);
-    assertEquals(uf.componentSize(1), 1);
-    assertEquals(uf.componentSize(2), 1);
-    assertEquals(uf.componentSize(3), 1);
-    assertEquals(uf.componentSize(4), 1);
+    assertThat(uf.componentSize(0)).isEqualTo(1);
+    assertThat(uf.componentSize(1)).isEqualTo(1);
+    assertThat(uf.componentSize(2)).isEqualTo(1);
+    assertThat(uf.componentSize(3)).isEqualTo(1);
+    assertThat(uf.componentSize(4)).isEqualTo(1);
 
     uf.unify(0, 1);
-    assertEquals(uf.componentSize(0), 2);
-    assertEquals(uf.componentSize(1), 2);
-    assertEquals(uf.componentSize(2), 1);
-    assertEquals(uf.componentSize(3), 1);
-    assertEquals(uf.componentSize(4), 1);
+    assertThat(uf.componentSize(0)).isEqualTo(2);
+    assertThat(uf.componentSize(1)).isEqualTo(2);
+    assertThat(uf.componentSize(2)).isEqualTo(1);
+    assertThat(uf.componentSize(3)).isEqualTo(1);
+    assertThat(uf.componentSize(4)).isEqualTo(1);
 
     uf.unify(1, 0);
-    assertEquals(uf.componentSize(0), 2);
-    assertEquals(uf.componentSize(1), 2);
-    assertEquals(uf.componentSize(2), 1);
-    assertEquals(uf.componentSize(3), 1);
-    assertEquals(uf.componentSize(4), 1);
+    assertThat(uf.componentSize(0)).isEqualTo(2);
+    assertThat(uf.componentSize(1)).isEqualTo(2);
+    assertThat(uf.componentSize(2)).isEqualTo(1);
+    assertThat(uf.componentSize(3)).isEqualTo(1);
+    assertThat(uf.componentSize(4)).isEqualTo(1);
 
     uf.unify(1, 2);
-    assertEquals(uf.componentSize(0), 3);
-    assertEquals(uf.componentSize(1), 3);
-    assertEquals(uf.componentSize(2), 3);
-    assertEquals(uf.componentSize(3), 1);
-    assertEquals(uf.componentSize(4), 1);
+    assertThat(uf.componentSize(0)).isEqualTo(3);
+    assertThat(uf.componentSize(1)).isEqualTo(3);
+    assertThat(uf.componentSize(2)).isEqualTo(3);
+    assertThat(uf.componentSize(3)).isEqualTo(1);
+    assertThat(uf.componentSize(4)).isEqualTo(1);
 
     uf.unify(0, 2);
-    assertEquals(uf.componentSize(0), 3);
-    assertEquals(uf.componentSize(1), 3);
-    assertEquals(uf.componentSize(2), 3);
-    assertEquals(uf.componentSize(3), 1);
-    assertEquals(uf.componentSize(4), 1);
+    assertThat(uf.componentSize(0)).isEqualTo(3);
+    assertThat(uf.componentSize(1)).isEqualTo(3);
+    assertThat(uf.componentSize(2)).isEqualTo(3);
+    assertThat(uf.componentSize(3)).isEqualTo(1);
+    assertThat(uf.componentSize(4)).isEqualTo(1);
 
     uf.unify(2, 1);
-    assertEquals(uf.componentSize(0), 3);
-    assertEquals(uf.componentSize(1), 3);
-    assertEquals(uf.componentSize(2), 3);
-    assertEquals(uf.componentSize(3), 1);
-    assertEquals(uf.componentSize(4), 1);
+    assertThat(uf.componentSize(0)).isEqualTo(3);
+    assertThat(uf.componentSize(1)).isEqualTo(3);
+    assertThat(uf.componentSize(2)).isEqualTo(3);
+    assertThat(uf.componentSize(3)).isEqualTo(1);
+    assertThat(uf.componentSize(4)).isEqualTo(1);
 
     uf.unify(3, 4);
-    assertEquals(uf.componentSize(0), 3);
-    assertEquals(uf.componentSize(1), 3);
-    assertEquals(uf.componentSize(2), 3);
-    assertEquals(uf.componentSize(3), 2);
-    assertEquals(uf.componentSize(4), 2);
+    assertThat(uf.componentSize(0)).isEqualTo(3);
+    assertThat(uf.componentSize(1)).isEqualTo(3);
+    assertThat(uf.componentSize(2)).isEqualTo(3);
+    assertThat(uf.componentSize(3)).isEqualTo(2);
+    assertThat(uf.componentSize(4)).isEqualTo(2);
 
     uf.unify(4, 3);
-    assertEquals(uf.componentSize(0), 3);
-    assertEquals(uf.componentSize(1), 3);
-    assertEquals(uf.componentSize(2), 3);
-    assertEquals(uf.componentSize(3), 2);
-    assertEquals(uf.componentSize(4), 2);
+    assertThat(uf.componentSize(0)).isEqualTo(3);
+    assertThat(uf.componentSize(1)).isEqualTo(3);
+    assertThat(uf.componentSize(2)).isEqualTo(3);
+    assertThat(uf.componentSize(3)).isEqualTo(2);
+    assertThat(uf.componentSize(4)).isEqualTo(2);
 
     uf.unify(1, 3);
-    assertEquals(uf.componentSize(0), 5);
-    assertEquals(uf.componentSize(1), 5);
-    assertEquals(uf.componentSize(2), 5);
-    assertEquals(uf.componentSize(3), 5);
-    assertEquals(uf.componentSize(4), 5);
+    assertThat(uf.componentSize(0)).isEqualTo(5);
+    assertThat(uf.componentSize(1)).isEqualTo(5);
+    assertThat(uf.componentSize(2)).isEqualTo(5);
+    assertThat(uf.componentSize(3)).isEqualTo(5);
+    assertThat(uf.componentSize(4)).isEqualTo(5);
 
     uf.unify(4, 0);
-    assertEquals(uf.componentSize(0), 5);
-    assertEquals(uf.componentSize(1), 5);
-    assertEquals(uf.componentSize(2), 5);
-    assertEquals(uf.componentSize(3), 5);
-    assertEquals(uf.componentSize(4), 5);
+    assertThat(uf.componentSize(0)).isEqualTo(5);
+    assertThat(uf.componentSize(1)).isEqualTo(5);
+    assertThat(uf.componentSize(2)).isEqualTo(5);
+    assertThat(uf.componentSize(3)).isEqualTo(5);
+    assertThat(uf.componentSize(4)).isEqualTo(5);
   }
 
   @Test
@@ -120,62 +121,62 @@ public class UnionFindTest {
     int sz = 7;
     UnionFind uf = new UnionFind(sz);
 
-    for (int i = 0; i < sz; i++) assertTrue(uf.connected(i, i));
+    for (int i = 0; i < sz; i++) assertThat(uf.connected(i, i)).isTrue();
 
     uf.unify(0, 2);
 
-    assertTrue(uf.connected(0, 2));
-    assertTrue(uf.connected(2, 0));
+    assertThat(uf.connected(0, 2)).isTrue();
+    assertThat(uf.connected(2, 0)).isTrue();
 
-    assertFalse(uf.connected(0, 1));
-    assertFalse(uf.connected(3, 1));
-    assertFalse(uf.connected(6, 4));
-    assertFalse(uf.connected(5, 0));
+    assertThat(uf.connected(0, 1)).isFalse();
+    assertThat(uf.connected(3, 1)).isFalse();
+    assertThat(uf.connected(6, 4)).isFalse();
+    assertThat(uf.connected(5, 0)).isFalse();
 
-    for (int i = 0; i < sz; i++) assertTrue(uf.connected(i, i));
+    for (int i = 0; i < sz; i++) assertThat(uf.connected(i, i)).isTrue();
 
     uf.unify(3, 1);
 
-    assertTrue(uf.connected(0, 2));
-    assertTrue(uf.connected(2, 0));
-    assertTrue(uf.connected(1, 3));
-    assertTrue(uf.connected(3, 1));
+    assertThat(uf.connected(0, 2)).isTrue();
+    assertThat(uf.connected(2, 0)).isTrue();
+    assertThat(uf.connected(1, 3)).isTrue();
+    assertThat(uf.connected(3, 1)).isTrue();
 
-    assertFalse(uf.connected(0, 1));
-    assertFalse(uf.connected(1, 2));
-    assertFalse(uf.connected(2, 3));
-    assertFalse(uf.connected(1, 0));
-    assertFalse(uf.connected(2, 1));
-    assertFalse(uf.connected(3, 2));
+    assertThat(uf.connected(0, 1)).isFalse();
+    assertThat(uf.connected(1, 2)).isFalse();
+    assertThat(uf.connected(2, 3)).isFalse();
+    assertThat(uf.connected(1, 0)).isFalse();
+    assertThat(uf.connected(2, 1)).isFalse();
+    assertThat(uf.connected(3, 2)).isFalse();
+    
+    assertThat(uf.connected(1, 4)).isFalse();
+    assertThat(uf.connected(2, 5)).isFalse();
+    assertThat(uf.connected(3, 6)).isFalse();
 
-    assertFalse(uf.connected(1, 4));
-    assertFalse(uf.connected(2, 5));
-    assertFalse(uf.connected(3, 6));
-
-    for (int i = 0; i < sz; i++) assertTrue(uf.connected(i, i));
+    for (int i = 0; i < sz; i++) assertThat(uf.connected(i, i)).isTrue();
 
     uf.unify(2, 5);
-    assertTrue(uf.connected(0, 2));
-    assertTrue(uf.connected(2, 0));
-    assertTrue(uf.connected(1, 3));
-    assertTrue(uf.connected(3, 1));
-    assertTrue(uf.connected(0, 5));
-    assertTrue(uf.connected(5, 0));
-    assertTrue(uf.connected(5, 2));
-    assertTrue(uf.connected(2, 5));
+    assertThat(uf.connected(0, 2)).isTrue();
+    assertThat(uf.connected(2, 0)).isTrue();
+    assertThat(uf.connected(1, 3)).isTrue();
+    assertThat(uf.connected(3, 1)).isTrue();
+    assertThat(uf.connected(0, 5)).isTrue();
+    assertThat(uf.connected(5, 0)).isTrue();
+    assertThat(uf.connected(5, 2)).isTrue();
+    assertThat(uf.connected(2, 5)).isTrue();
 
-    assertFalse(uf.connected(0, 1));
-    assertFalse(uf.connected(1, 2));
-    assertFalse(uf.connected(2, 3));
-    assertFalse(uf.connected(1, 0));
-    assertFalse(uf.connected(2, 1));
-    assertFalse(uf.connected(3, 2));
+    assertThat(uf.connected(0, 1)).isFalse();
+    assertThat(uf.connected(1, 2)).isFalse();
+    assertThat(uf.connected(2, 3)).isFalse();
+    assertThat(uf.connected(1, 0)).isFalse();
+    assertThat(uf.connected(2, 1)).isFalse();
+    assertThat(uf.connected(3, 2)).isFalse();
 
-    assertFalse(uf.connected(4, 6));
-    assertFalse(uf.connected(4, 5));
-    assertFalse(uf.connected(1, 6));
+    assertThat(uf.connected(4, 6)).isFalse();
+    assertThat(uf.connected(4, 5)).isFalse();
+    assertThat(uf.connected(1, 6)).isFalse();
 
-    for (int i = 0; i < sz; i++) assertTrue(uf.connected(i, i));
+    for (int i = 0; i < sz; i++) assertThat(uf.connected(i, i)).isTrue();
 
     // Connect everything
     uf.unify(1, 2);
@@ -184,7 +185,7 @@ public class UnionFindTest {
 
     for (int i = 0; i < sz; i++) {
       for (int j = 0; j < sz; j++) {
-        assertTrue(uf.connected(i, j));
+        assertThat(uf.connected(i, j)).isTrue();
       }
     }
   }
@@ -193,28 +194,28 @@ public class UnionFindTest {
   public void testSize() {
 
     UnionFind uf = new UnionFind(5);
-    assertEquals(uf.size(), 5);
+    assertThat(uf.size()).isEqualTo(5);
     uf.unify(0, 1);
     uf.find(3);
-    assertEquals(uf.size(), 5);
+    assertThat(uf.size()).isEqualTo(5);
     uf.unify(1, 2);
-    assertEquals(uf.size(), 5);
+    assertThat(uf.size()).isEqualTo(5);
     uf.unify(0, 2);
     uf.find(1);
-    assertEquals(uf.size(), 5);
+    assertThat(uf.size()).isEqualTo(5);
     uf.unify(2, 1);
-    assertEquals(uf.size(), 5);
+    assertThat(uf.size()).isEqualTo(5);
     uf.unify(3, 4);
     uf.find(0);
-    assertEquals(uf.size(), 5);
+    assertThat(uf.size()).isEqualTo(5);
     uf.unify(4, 3);
     uf.find(3);
-    assertEquals(uf.size(), 5);
+    assertThat(uf.size()).isEqualTo(5);
     uf.unify(1, 3);
-    assertEquals(uf.size(), 5);
+    assertThat(uf.size()).isEqualTo(5);
     uf.find(2);
     uf.unify(4, 0);
-    assertEquals(uf.size(), 5);
+    assertThat(uf.size()).isEqualTo(5);
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/com/williamfiset/algorithms/datastructures/unionfind/UnionFindTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/unionfind/UnionFindTest.java
@@ -148,7 +148,7 @@ public class UnionFindTest {
     assertThat(uf.connected(1, 0)).isFalse();
     assertThat(uf.connected(2, 1)).isFalse();
     assertThat(uf.connected(3, 2)).isFalse();
-    
+
     assertThat(uf.connected(1, 4)).isFalse();
     assertThat(uf.connected(2, 5)).isFalse();
     assertThat(uf.connected(3, 6)).isFalse();

--- a/src/test/java/com/williamfiset/algorithms/other/LazyRangeAdderTest.java
+++ b/src/test/java/com/williamfiset/algorithms/other/LazyRangeAdderTest.java
@@ -1,6 +1,6 @@
 package com.williamfiset.algorithms.other;
 
-import static org.junit.Assert.*;
+import static com.google.common.truth.Truth.assertThat;
 
 import org.junit.Test;
 
@@ -15,7 +15,7 @@ public class LazyRangeAdderTest {
     lazyRangeAdder.add(2, 2, 30);
     lazyRangeAdder.done();
     int[] expected = {20, 35, 70, 60};
-    assertArrayEquals(expected, a);
+    assertThat(a).isEqualTo(expected);
   }
 
   @Test
@@ -27,7 +27,7 @@ public class LazyRangeAdderTest {
     lazyRangeAdder.add(5, 6, -73);
     lazyRangeAdder.done();
     int[] expected = {371, 412, 560, 668, 467, 152, 101};
-    assertArrayEquals(expected, a);
+    assertThat(a).isEqualTo(expected);
   }
 
   @Test
@@ -56,7 +56,7 @@ public class LazyRangeAdderTest {
 
       lazyRangeAdder.done();
 
-      assertArrayEquals(arr1, arr2);
+      assertThat(arr1).isEqualTo(arr2);
     }
   }
 

--- a/src/test/java/com/williamfiset/algorithms/other/SlidingWindowMaximumTest.java
+++ b/src/test/java/com/williamfiset/algorithms/other/SlidingWindowMaximumTest.java
@@ -1,6 +1,6 @@
 package com.williamfiset.algorithms.other;
 
-import static org.junit.Assert.*;
+import static com.google.common.truth.Truth.assertThat;
 
 import org.junit.*;
 
@@ -15,27 +15,27 @@ public class SlidingWindowMaximumTest {
     SlidingWindowMaximum w = new SlidingWindowMaximum(values);
 
     w.advance();
-    assertEquals(1, w.getMax());
+    assertThat(w.getMax()).isEqualTo(1);
     w.advance();
-    assertEquals(2, w.getMax());
+    assertThat(w.getMax()).isEqualTo(2);
     w.advance();
-    assertEquals(2, w.getMax());
+    assertThat(w.getMax()).isEqualTo(2);
     w.shrink();
-    assertEquals(2, w.getMax());
+    assertThat(w.getMax()).isEqualTo(2);
     w.shrink();
-    assertEquals(1, w.getMax());
+    assertThat(w.getMax()).isEqualTo(1);
     w.advance();
-    assertEquals(3, w.getMax());
+    assertThat(w.getMax()).isEqualTo(3);
     w.advance();
-    assertEquals(3, w.getMax());
+    assertThat(w.getMax()).isEqualTo(3);
     w.advance();
-    assertEquals(4, w.getMax());
+    assertThat(w.getMax()).isEqualTo(4);
     w.shrink();
-    assertEquals(4, w.getMax());
+    assertThat(w.getMax()).isEqualTo(4);
     w.shrink();
-    assertEquals(4, w.getMax());
+    assertThat(w.getMax()).isEqualTo(4);
     w.shrink();
-    assertEquals(4, w.getMax());
+    assertThat(w.getMax()).isEqualTo(4);
   }
 
   @Test
@@ -85,7 +85,7 @@ public class SlidingWindowMaximumTest {
       int max = Integer.MIN_VALUE;
       for (int i = lo; i < hi; i++) max = Math.max(max, ar[i]);
 
-      assertEquals(max, window.getMax());
+      assertThat(window.getMax()).isEqualTo(max);
     }
   }
 }

--- a/src/test/java/com/williamfiset/algorithms/search/InterpolationSearchTest.java
+++ b/src/test/java/com/williamfiset/algorithms/search/InterpolationSearchTest.java
@@ -10,27 +10,27 @@ public class InterpolationSearchTest {
   public void testCoverage1() {
     int[] arr = {0, 1, 2, 3, 4, 5};
     int index = InterpolationSearch.interpolationSearch(arr, 2);
-    assertThat(index == 2);
+    assertThat(index).isEqualTo(2);
   }
 
   @Test
   public void testCoverage2() {
     int[] arr = {0, 1, 2, 3, 4, 5};
     int index = InterpolationSearch.interpolationSearch(arr, 5);
-    assertThat(index == 5);
+    assertThat(index).isEqualTo(5);
   }
 
   @Test
   public void testCoverage3() {
     int[] arr = {0, 1, 2, 3, 4, 5};
     int index = InterpolationSearch.interpolationSearch(arr, -1);
-    assertThat(index == -1);
+    assertThat(index).isEqualTo(-1);
   }
 
   @Test
   public void testCoverage4() {
     int[] arr = {0, 1, 2, 3, 4, 5};
     int index = InterpolationSearch.interpolationSearch(arr, 8);
-    assertThat(index == -1);
+    assertThat(index).isEqualTo(-1);
   }
 }

--- a/src/test/java/com/williamfiset/algorithms/search/InterpolationSearchTest.java
+++ b/src/test/java/com/williamfiset/algorithms/search/InterpolationSearchTest.java
@@ -1,6 +1,6 @@
 package com.williamfiset.algorithms.search;
 
-import static org.junit.Assert.*;
+import static com.google.common.truth.Truth.assertThat;
 
 import org.junit.Test;
 
@@ -10,27 +10,27 @@ public class InterpolationSearchTest {
   public void testCoverage1() {
     int[] arr = {0, 1, 2, 3, 4, 5};
     int index = InterpolationSearch.interpolationSearch(arr, 2);
-    assertTrue(index == 2);
+    assertThat(index == 2);
   }
 
   @Test
   public void testCoverage2() {
     int[] arr = {0, 1, 2, 3, 4, 5};
     int index = InterpolationSearch.interpolationSearch(arr, 5);
-    assertTrue(index == 5);
+    assertThat(index == 5);
   }
 
   @Test
   public void testCoverage3() {
     int[] arr = {0, 1, 2, 3, 4, 5};
     int index = InterpolationSearch.interpolationSearch(arr, -1);
-    assertTrue(index == -1);
+    assertThat(index == -1);
   }
 
   @Test
   public void testCoverage4() {
     int[] arr = {0, 1, 2, 3, 4, 5};
     int index = InterpolationSearch.interpolationSearch(arr, 8);
-    assertTrue(index == -1);
+    assertThat(index == -1);
   }
 }

--- a/src/test/java/com/williamfiset/algorithms/sorting/RadixSortTest.java
+++ b/src/test/java/com/williamfiset/algorithms/sorting/RadixSortTest.java
@@ -1,7 +1,6 @@
 package com.williamfiset.algorithms.sorting;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.*;
 
 import java.util.Arrays;
 import java.util.Random;

--- a/src/test/java/com/williamfiset/algorithms/sorting/SortingTest.java
+++ b/src/test/java/com/williamfiset/algorithms/sorting/SortingTest.java
@@ -1,7 +1,6 @@
 package com.williamfiset.algorithms.sorting;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.*;
 
 import com.williamfiset.algorithms.utils.TestUtils;
 import java.util.Arrays;

--- a/src/test/java/com/williamfiset/algorithms/strings/LongestCommonSubstringTest.java
+++ b/src/test/java/com/williamfiset/algorithms/strings/LongestCommonSubstringTest.java
@@ -3,10 +3,8 @@
  */
 package com.williamfiset.algorithms.strings;
 
-// TODO(williamfiset): Replace junit asserts with all Google truth assertions.
 import static com.google.common.truth.Truth.assertThat;
 import static com.williamfiset.algorithms.strings.LongestCommonSubstring.LcsSolver;
-import static org.junit.Assert.*;
 
 import com.google.common.collect.ImmutableList;
 import com.williamfiset.algorithms.utils.TestUtils;
@@ -73,7 +71,7 @@ public class LongestCommonSubstringTest {
 
       LcsSolver solver = new LcsSolver(strings);
       TreeSet<String> lcss = solver.getLongestCommonSubstrings(k);
-      assertEquals(expectedLcss, lcss);
+      assertThat(expectedLcss).isEqualTo(lcss);
     }
   }
 
@@ -146,7 +144,7 @@ public class LongestCommonSubstringTest {
     LcsSolver solver = new LcsSolver(strs);
     TreeSet<String> lcss = solver.getLongestCommonSubstrings(k);
 
-    assertEquals(ans.size(), lcss.size());
+    assertThat(ans.size()).isEqualTo(lcss.size());
   }
 
   @Test
@@ -160,7 +158,7 @@ public class LongestCommonSubstringTest {
 
     LcsSolver solver = new LcsSolver(strs);
     TreeSet<String> lcss = solver.getLongestCommonSubstrings(k);
-    assertEquals(ans, lcss);
+    assertThat(ans).isEqualTo(lcss);
   }
 
   @Test
@@ -173,7 +171,7 @@ public class LongestCommonSubstringTest {
 
     LcsSolver solver = new LcsSolver(strs);
     TreeSet<String> lcss = solver.getLongestCommonSubstrings(k);
-    assertEquals(ans, lcss);
+    assertThat(ans).isEqualTo(lcss);
   }
 
   @Test
@@ -189,7 +187,7 @@ public class LongestCommonSubstringTest {
 
     LcsSolver solver = new LcsSolver(strs);
     TreeSet<String> lcss = solver.getLongestCommonSubstrings(k);
-    assertEquals(ans, lcss);
+    assertThat(ans).isEqualTo(lcss);
   }
 
   @Test
@@ -207,7 +205,7 @@ public class LongestCommonSubstringTest {
 
     LcsSolver solver = new LcsSolver(strs);
     TreeSet<String> lcss = solver.getLongestCommonSubstrings(k);
-    assertEquals(ans, lcss);
+    assertThat(ans).isEqualTo(lcss);
   }
 
   @Test
@@ -220,7 +218,7 @@ public class LongestCommonSubstringTest {
 
     LcsSolver solver = new LcsSolver(strs);
     TreeSet<String> lcss = solver.getLongestCommonSubstrings(k);
-    assertEquals(ans, lcss);
+    assertThat(ans).isEqualTo(lcss);
   }
 
   @Test
@@ -236,7 +234,7 @@ public class LongestCommonSubstringTest {
 
     LcsSolver solver = new LcsSolver(strs);
     TreeSet<String> lcss = solver.getLongestCommonSubstrings(k);
-    assertEquals(ans, lcss);
+    assertThat(ans).isEqualTo(lcss);
   }
 
   @Test
@@ -253,7 +251,7 @@ public class LongestCommonSubstringTest {
 
     LcsSolver solver = new LcsSolver(strs);
     TreeSet<String> lcss = solver.getLongestCommonSubstrings(k);
-    assertEquals(ans, lcss);
+    assertThat(ans).isEqualTo(lcss);
   }
 
   @Test
@@ -269,7 +267,7 @@ public class LongestCommonSubstringTest {
 
     LcsSolver solver = new LcsSolver(strs);
     TreeSet<String> lcss = solver.getLongestCommonSubstrings(k);
-    assertEquals(ans, lcss);
+    assertThat(ans).isEqualTo(lcss);
   }
 
   @Test
@@ -285,7 +283,7 @@ public class LongestCommonSubstringTest {
 
     LcsSolver solver = new LcsSolver(strs);
     TreeSet<String> lcss = solver.getLongestCommonSubstrings(k);
-    assertEquals(ans, lcss);
+    assertThat(ans).isEqualTo(lcss);
   }
 
   @Test
@@ -305,7 +303,7 @@ public class LongestCommonSubstringTest {
 
     LcsSolver solver = new LcsSolver(strs);
     TreeSet<String> lcss = solver.getLongestCommonSubstrings(k);
-    assertEquals(ans, lcss);
+    assertThat(ans).isEqualTo(lcss);
   }
 
   @Test
@@ -384,7 +382,7 @@ public class LongestCommonSubstringTest {
 
       LcsSolver solver = new LcsSolver(strs);
       TreeSet<String> lcss = solver.getLongestCommonSubstrings(k);
-      assertEquals(ans, lcss);
+      assertThat(ans).isEqualTo(lcss);
     }
   }
 }


### PR DESCRIPTION
- Updated all assertions to use Google Truth in place of JUnit and Jupiter
- Refactored assertions as per https://truth.dev/faq for suggestions like:
```
Does it matter if I write assertThat(a).isEqualTo(b) or assertThat(b).isEqualTo(a)?
Yes! Truth’s error messages will make more sense if you always use this pattern:

assertThat(actualValue).isEqualTo(expectedValue);
```
- Removed imports and cleaned up old comments
- Print stack trace on error instead of a test message
- Closes #196 