### PR TITLE
[search/TernarySearchDiscrete.java] return the value, not the index, to be consistent with above

### DIFF
--- a/src/main/java/com/williamfiset/algorithms/search/TernarySearchDiscrete.java
+++ b/src/main/java/com/williamfiset/algorithms/search/TernarySearchDiscrete.java
@@ -41,7 +41,7 @@ public class TernarySearchDiscrete {
       } else if (res1 > res2) lo = mid1;
       else hi = mid2;
     }
-    return lo;
+    return f(lo);
   }
 
   public static void main(String[] args) {


### PR DESCRIPTION
https://github.com/williamfiset/Algorithms/blob/6bd2d441add760cb3ce3bac92803e27fbfabeb68/src/main/java/com/williamfiset/algorithms/search/TernarySearchDiscrete.java#L32-L45

In line 34 and 35 the minimum value is returned, which is consistent with the test below. However at line 44 the index is returned. I think you probably meant to return the value at `lo`, or `f(lo)`.