### PR TITLE
Bucket sort bug fix

### DIFF
--- a/src/main/java/com/williamfiset/algorithms/sorting/BucketSort.java
+++ b/src/main/java/com/williamfiset/algorithms/sorting/BucketSort.java
@@ -38,7 +38,6 @@ public class BucketSort implements InplaceSort {
     // Place each element in a bucket
     for (int i = 0; i < N; i++) {
       int bi = numBuckets * (ar[i] - minValue) / M;
-      System.out.printf("%d placed into bucket %d\n", ar[i], bi);
       List<Integer> bucket = buckets.get(bi);
       bucket.add(ar[i]);
     }

--- a/src/main/java/com/williamfiset/algorithms/sorting/BucketSort.java
+++ b/src/main/java/com/williamfiset/algorithms/sorting/BucketSort.java
@@ -38,6 +38,7 @@ public class BucketSort implements InplaceSort {
     // Place each element in a bucket
     for (int i = 0; i < N; i++) {
       int bi = (ar[i] - minValue) / M;
+      System.out.printf("%d placed into bucket %d\n", ar[i], bi);
       List<Integer> bucket = buckets.get(bi);
       bucket.add(ar[i]);
     }

--- a/src/main/java/com/williamfiset/algorithms/sorting/BucketSort.java
+++ b/src/main/java/com/williamfiset/algorithms/sorting/BucketSort.java
@@ -37,7 +37,7 @@ public class BucketSort implements InplaceSort {
 
     // Place each element in a bucket
     for (int i = 0; i < N; i++) {
-      int bi = (ar[i] - minValue) / M;
+      int bi = numBuckets * (ar[i] - minValue) / M;
       System.out.printf("%d placed into bucket %d\n", ar[i], bi);
       List<Integer> bucket = buckets.get(bi);
       bucket.add(ar[i]);


### PR DESCRIPTION
In the current implementation all elements will be placed into bucket 0 (`ar[i] - minValue` is always less than `M`, which is `maxValue - minValue + 1`, so `ar[i] - minValue) / M` must be 0) (see commit https://github.com/williamfiset/Algorithms/commit/be4b0a9533de73461261e9aa6aca35b9e0c50f41 )

To place into different buckets the bucket index should be calculated as `numBuckets * (ar[i] - minValue) / M`