### PR TITLE
Recently merged PR's bug fix in UnionFind

### DIFF
--- a/src/main/java/com/williamfiset/algorithms/datastructures/unionfind/UnionFind.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/unionfind/UnionFind.java
@@ -93,11 +93,11 @@ public class UnionFind {
     if (sz[root1] < sz[root2]) {
       sz[root2] += sz[root1];
       id[root1] = root2;
-      id[root2] = 0;
+      sz[root2] = 0;
     } else {
       sz[root1] += sz[root2];
       id[root2] = root1;
-      id[root1] = 0;
+      sz[root1] = 0;
     }
 
     // Since the roots found are different we know that the


### PR DESCRIPTION
Accidentally in this PR, I have make id[root] = 0 instead of making sz[root] = 0. In this PR, I am fixing that by changing the modified array as sz.