### PR TITLE
[ISSUEFIX]: Added size check for addAt() method in DoublyLinkedList.

### DIFF
--- a/src/main/java/com/williamfiset/algorithms/datastructures/linkedlist/DoublyLinkedList.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/linkedlist/DoublyLinkedList.java
@@ -79,7 +79,7 @@ public class DoublyLinkedList<T> implements Iterable<T> {
 
   // Add an element at a specified index
   public void addAt(int index, T data) throws Exception {
-    if (index < 0) {
+    if (index < 0 || index > size) {
       throw new Exception("Illegal Index");
     }
     if (index == 0) {

--- a/src/test/java/com/williamfiset/algorithms/datastructures/linkedlist/LinkedListTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/linkedlist/LinkedListTest.java
@@ -74,6 +74,8 @@ public class LinkedListTest {
     assertThat(list.size()).isEqualTo(4);
     list.addAt(1, 8);
     assertThat(list.size()).isEqualTo(5);
+    list.addAt(100, 8);
+    assertThat(list.size()).isEqualTo(6);
   }
 
   @Test


### PR DESCRIPTION
Index greater than the size of the list will throw exception. This is handled by checking the value of index against the size of the list.