### PR TITLE
fix: missing "{" in DoublyLinkedList.java

### DIFF
--- a/src/main/java/com/williamfiset/algorithms/datastructures/linkedlist/DoublyLinkedList.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/linkedlist/DoublyLinkedList.java
@@ -197,12 +197,12 @@ public class DoublyLinkedList<T> implements Iterable<T> {
         trav = trav.next;
       }
       // Search from the back of the list
-    } else
+    } else {
       for (i = size - 1, trav = tail; i != index; i--) {
         trav = trav.prev;
       }
-
-    return remove(trav);
+      
+      return remove(trav);
   }
 
   // Remove a particular value in the linked list, O(n)


### PR DESCRIPTION
On line 200, there was a missing "{" bracket in the `else` clause which would have thrown an error when run. I fixed it by adding that missing "{" bracket.