### PR TITLE
Articulation points alg at the root node

### DIFF
--- a/src/main/java/com/williamfiset/algorithms/graphtheory/ArticulationPointsAdjacencyList.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/ArticulationPointsAdjacencyList.java
@@ -56,14 +56,16 @@ public class ArticulationPointsAdjacencyList {
 
     visited[at] = true;
     low[at] = ids[at] = id++;
+    int components = 0;
 
     List<Integer> edges = graph.get(at);
     for (Integer to : edges) {
       if (to == parent) continue;
       if (!visited[to]) {
+        components++;
         dfs(root, to, at);
         low[at] = min(low[at], low[to]);
-        if (ids[at] <= low[to]) {
+        if (parent == -1 && components > 1 || parent != -1 && ids[at] <= low[to]) {
           isArticulationPoint[at] = true;
         }
       } else {


### PR DESCRIPTION
In the current implementation, the noot node is always marked as an articulation point but this is not correct. To determine if the root node is an articulation point, an additional variable called "components" is introduced. This variable counts the number of connected components connected to the root node in the case where the root node is removed. If it is more than 1, that means that the root node would split the graph.