### PR TITLE
feat: Added dependency and plugin needed for jacoco (issue #2)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ buildscript {
 plugins {
   // https://github.com/sherter/google-java-format-gradle-plugin
   // id "com.github.sherter.google-java-format" version "0.9"
+  id 'jacoco'
 }
 
 apply plugin: 'java'
@@ -45,6 +46,9 @@ dependencies {
 
   // Test mocking framework
   testImplementation "org.mockito:mockito-core:1.+"
+
+  // Jacoco
+  implementation 'org.jacoco:org.jacoco.core:0.8.7'
 }
 
 test {
@@ -72,4 +76,8 @@ compileTestJava {
 task buildDependenciesFolder(type: Copy) {
   from configurations.implementation
   into './dependencies'
+}
+
+jacoco {
+  toolVersion = "0.8.7"
 }


### PR DESCRIPTION
Added dependency and plugin needed for jacoco
Can be run with ./gradlew test jacocoTestReport 
And the report will be in filepath build/reports/jacoco/test/html