### PR TITLE
Update README URL Checker Action

### DIFF
--- a/.github/workflows/readme-url-checker.yml
+++ b/.github/workflows/readme-url-checker.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby 2.6
       uses: actions/setup-ruby@v1
       with:

--- a/.github/workflows/readme-url-checker.yml
+++ b/.github/workflows/readme-url-checker.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.0
 


### PR DESCRIPTION
_Fixes #376_

This PR:

- Bumps up [actions/checkout](https://github.com/actions/checkout) to [`v3`](https://github.com/actions/checkout/tree/v3)
- Replaces [actions/setup-ruby](https://github.com/actions/setup-ruby) with [ruby/setup-ruby](https://github.com/ruby/setup-ruby)
  [actions/setup-ruby](https://github.com/actions/setup-ruby) is deprecated since February 2021 and should no longer be used.