### PR TITLE
Restore Code Formatting Checks

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v3
       with:
-        java-version: 8
+        java-version: 11
         distribution: 'temurin'
         cache: 'gradle'
     - name: Validate Gradle Wrapper
@@ -46,25 +46,21 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v3
       with:
-        java-version: 8
+        java-version: 11
         distribution: 'temurin'
         cache: 'gradle'
     - name: Validate Gradle Wrapper
       uses: gradle/wrapper-validation-action@v1
-    # The google formatter is broken atm. Disabling for now.
     - name: Verify all Java files are formatted correctly according to the Google Java Style Guide using Gradle
       uses: gradle/gradle-build-action@v2
-      if: ${{ false }}
       id: verifygooglejavaformat
       with:
         gradle-version: wrapper
-        arguments: verifyGoogleJavaFormat
+        arguments: spotlessJavaCheck
     - name: Create summary if format check failed
-      if: ${{ false }}
-      # Enable this when Google Java formatter is enabled
-      # if: ${{ steps.verifygooglejavaformat.outcome == 'failure' }}
+      if: ${{ steps.verifygooglejavaformat.outcome == 'failure' }}
       run: |
-        echo "Run the command `./gradlew goJF` to fix Java formatting." >> $GITHUB_STEP_SUMMARY
+        echo "Run the command `./gradlew spotlessApply` to fix Java formatting." >> $GITHUB_STEP_SUMMARY

--- a/build.gradle
+++ b/build.gradle
@@ -7,14 +7,12 @@ buildscript {
 }
 
 plugins {
-  // https://github.com/sherter/google-java-format-gradle-plugin
-  // id "com.github.sherter.google-java-format" version "0.9"
+  // https://github.com/diffplug/spotless
+  id("com.diffplug.spotless") version "6.18.0"
 }
 
 apply plugin: 'java'
 apply plugin: 'application'
-// Formatting tool doesn't support Java 17+
-// apply plugin: "com.github.sherter.google-java-format"
 
 mainClassName = findProperty("main") ?: "com.williamfiset.algorithms.${findProperty("algorithm") ?: 'missingPackage.missingClass'}"
 
@@ -42,6 +40,12 @@ dependencies {
 
   // Test mocking framework
   testImplementation "org.mockito:mockito-core:5.+"
+}
+
+spotless {
+  java {
+    googleJavaFormat()
+  }
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -27,23 +27,21 @@ repositories {
 // 'compile' for project dependencies.
 dependencies {
   // Apache commons lang
-  testImplementation 'org.apache.commons:commons-lang3:3.6'
-
-  // JUnit framework
-  testImplementation 'junit:junit:4.+'
+  testImplementation 'org.apache.commons:commons-lang3:3.12.0'
 
   // JUnit 5 / Jupiter
-  testImplementation('org.junit.jupiter:junit-jupiter-api:5.4.2')
-   
+  testImplementation('org.junit.jupiter:junit-jupiter:5.9.3')
+  testRuntimeOnly('org.junit.jupiter:junit-jupiter-engine:5.9.3')
+
   // Google Guava lib
-  testImplementation group: 'com.google.guava', name: 'guava', version: '22.0'
+  testImplementation group: 'com.google.guava', name: 'guava', version: '23.0'
 
   // Google Truth test framework
   // https://mvnrepository.com/artifact/com.google.truth/truth
-  testImplementation group: 'com.google.truth', name: 'truth', version: '1.0'
+  testImplementation group: 'com.google.truth', name: 'truth', version: '1.1.5'
 
   // Test mocking framework
-  testImplementation "org.mockito:mockito-core:1.+"
+  testImplementation "org.mockito:mockito-core:5.+"
 }
 
 test {

--- a/src/main/java/com/williamfiset/algorithms/datastructures/stack/ArrayStack.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/stack/ArrayStack.java
@@ -3,7 +3,9 @@ package com.williamfiset.algorithms.datastructures.stack;
 import java.util.Arrays;
 import java.util.EmptyStackException;
 
-/** @author liujingkun */
+/**
+ * @author liujingkun
+ */
 public class ArrayStack<T> implements Stack<T> {
   private int size;
   private int capacity;

--- a/src/main/java/com/williamfiset/algorithms/datastructures/stack/Stack.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/stack/Stack.java
@@ -1,6 +1,8 @@
 package com.williamfiset.algorithms.datastructures.stack;
 
-/** @author liujingkun */
+/**
+ * @author liujingkun
+ */
 public interface Stack<T> {
   // return the number of elements in the stack
   public int size();

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/ConnectedComponentsDfsSolverAdjacencyList.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/ConnectedComponentsDfsSolverAdjacencyList.java
@@ -19,7 +19,9 @@ public class ConnectedComponentsDfsSolverAdjacencyList {
   private boolean[] visited;
   private List<List<Integer>> graph;
 
-  /** @param graph - An undirected graph as an adjacency list. */
+  /**
+   * @param graph - An undirected graph as an adjacency list.
+   */
   public ConnectedComponentsDfsSolverAdjacencyList(List<List<Integer>> graph) {
     if (graph == null) throw new NullPointerException();
     this.n = graph.size();

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/networkflow/NetworkFlowSolverBase.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/networkflow/NetworkFlowSolverBase.java
@@ -1,4 +1,6 @@
-/** @author William Fiset, william.alexandre.fiset@gmail.com */
+/**
+ * @author William Fiset, william.alexandre.fiset@gmail.com
+ */
 package com.williamfiset.algorithms.graphtheory.networkflow;
 
 import java.util.ArrayList;

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/treealgorithms/LowestCommonAncestor.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/treealgorithms/LowestCommonAncestor.java
@@ -14,7 +14,7 @@ public class LowestCommonAncestor {
 
     // Useful constructor for root node.
     public TreeNode(int id) {
-      this(id, /*parent=*/ null);
+      this(id, /* parent= */ null);
     }
 
     public TreeNode(int id, TreeNode parent) {

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/treealgorithms/LowestCommonAncestorEulerTour.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/treealgorithms/LowestCommonAncestorEulerTour.java
@@ -94,7 +94,7 @@ public class LowestCommonAncestorEulerTour {
 
     // Useful constructor for root node.
     public TreeNode(int index) {
-      this(index, /*parent=*/ null);
+      this(index, /* parent= */ null);
     }
 
     public TreeNode(int index, TreeNode parent) {
@@ -192,7 +192,7 @@ public class LowestCommonAncestorEulerTour {
     last = new int[n];
 
     // Do depth first search to construct Euler tour.
-    dfs(root, /*depth=*/ 0);
+    dfs(root, /* depth= */ 0);
 
     // Initialize and build sparse table on the `nodeDepth` array which will
     // allow us to index into the `nodeOrder` array and return the LCA.

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/treealgorithms/RootingTree.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/treealgorithms/RootingTree.java
@@ -19,7 +19,7 @@ public class RootingTree {
 
     // Useful constructor for root node.
     public TreeNode(int id) {
-      this(id, /*parent=*/ null);
+      this(id, /* parent= */ null);
     }
 
     public TreeNode(int id, TreeNode parent) {

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/treealgorithms/TreeIsomorphism.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/treealgorithms/TreeIsomorphism.java
@@ -19,7 +19,7 @@ public class TreeIsomorphism {
 
     // Useful constructor for root node.
     public TreeNode(int id) {
-      this(id, /*parent=*/ null);
+      this(id, /* parent= */ null);
     }
 
     public TreeNode(int id, TreeNode parent) {

--- a/src/main/java/com/williamfiset/algorithms/math/NChooseRModPrime.java
+++ b/src/main/java/com/williamfiset/algorithms/math/NChooseRModPrime.java
@@ -1,4 +1,6 @@
-/** @author Rohit Mazumder, mazumder.rohit7@gmai.com */
+/**
+ * @author Rohit Mazumder, mazumder.rohit7@gmai.com
+ */
 package com.williamfiset.algorithms.math;
 
 import java.math.BigInteger;

--- a/src/test/java/com/williamfiset/algorithms/datastructures/balancedtree/AVLTreeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/balancedtree/AVLTreeTest.java
@@ -6,8 +6,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.TreeSet;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.api.*;
 
 public class AVLTreeTest {
 
@@ -18,7 +18,7 @@ public class AVLTreeTest {
 
   private AVLTreeRecursive<Integer> tree;
 
-  @Before
+  @BeforeEach
   public void setup() {
     tree = new AVLTreeRecursive<>();
   }

--- a/src/test/java/com/williamfiset/algorithms/datastructures/balancedtree/AVLTreeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/balancedtree/AVLTreeTest.java
@@ -6,7 +6,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.TreeSet;
-
 import org.junit.jupiter.api.*;
 
 public class AVLTreeTest {

--- a/src/test/java/com/williamfiset/algorithms/datastructures/balancedtree/RedBlackTreeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/balancedtree/RedBlackTreeTest.java
@@ -4,7 +4,6 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.*;
-
 import org.junit.jupiter.api.*;
 
 public class RedBlackTreeTest {

--- a/src/test/java/com/williamfiset/algorithms/datastructures/balancedtree/RedBlackTreeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/balancedtree/RedBlackTreeTest.java
@@ -1,10 +1,11 @@
 package com.williamfiset.algorithms.datastructures.balancedtree;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.*;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.api.*;
 
 public class RedBlackTreeTest {
 
@@ -15,14 +16,14 @@ public class RedBlackTreeTest {
 
   private RedBlackTree<Integer> tree;
 
-  @Before
+  @BeforeEach
   public void setup() {
     tree = new RedBlackTree<>();
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testNullInsertion() {
-    tree.insert(null);
+    assertThrows(IllegalArgumentException.class, () -> tree.insert(null));
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/balancedtree/TreapTreeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/balancedtree/TreapTreeTest.java
@@ -1,13 +1,14 @@
 package com.williamfiset.algorithms.datastructures.balancedtree;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.TreeSet;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.api.*;
 
 public class TreapTreeTest {
 
@@ -18,14 +19,14 @@ public class TreapTreeTest {
 
   private TreapTree<Integer> tree;
 
-  @Before
+  @BeforeEach
   public void setup() {
     tree = new TreapTree<>();
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testNullInsertion() {
-    tree.insert(null);
+    assertThrows(IllegalArgumentException.class, () -> tree.insert(null));
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/balancedtree/TreapTreeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/balancedtree/TreapTreeTest.java
@@ -7,7 +7,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.TreeSet;
-
 import org.junit.jupiter.api.*;
 
 public class TreapTreeTest {

--- a/src/test/java/com/williamfiset/algorithms/datastructures/binarysearchtree/BinarySearchTreeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/binarysearchtree/BinarySearchTreeTest.java
@@ -10,7 +10,6 @@ import java.util.ConcurrentModificationException;
 import java.util.Deque;
 import java.util.Iterator;
 import java.util.List;
-
 import org.junit.jupiter.api.*;
 
 class TestTreeNode {
@@ -214,12 +213,14 @@ public class BinarySearchTreeTest {
 
     Iterator<Integer> iter = bst.traverse(TreeTraversalOrder.PRE_ORDER);
 
-    assertThrows(ConcurrentModificationException.class, () -> {
-      while (iter.hasNext()) {
-        bst.add(0);
-        iter.next();
-      }
-    });
+    assertThrows(
+        ConcurrentModificationException.class,
+        () -> {
+          while (iter.hasNext()) {
+            bst.add(0);
+            iter.next();
+          }
+        });
   }
 
   @Test
@@ -233,12 +234,14 @@ public class BinarySearchTreeTest {
 
     Iterator<Integer> iter = bst.traverse(TreeTraversalOrder.IN_ORDER);
 
-    assertThrows(ConcurrentModificationException.class, () -> {
-      while (iter.hasNext()) {
-        bst.add(0);
-        iter.next();
-      }
-    });
+    assertThrows(
+        ConcurrentModificationException.class,
+        () -> {
+          while (iter.hasNext()) {
+            bst.add(0);
+            iter.next();
+          }
+        });
   }
 
   @Test
@@ -252,12 +255,14 @@ public class BinarySearchTreeTest {
 
     Iterator<Integer> iter = bst.traverse(TreeTraversalOrder.POST_ORDER);
 
-    assertThrows(ConcurrentModificationException.class, () -> {
-      while (iter.hasNext()) {
-        bst.add(0);
-        iter.next();
-      }
-    });
+    assertThrows(
+        ConcurrentModificationException.class,
+        () -> {
+          while (iter.hasNext()) {
+            bst.add(0);
+            iter.next();
+          }
+        });
   }
 
   @Test
@@ -271,12 +276,14 @@ public class BinarySearchTreeTest {
 
     Iterator<Integer> iter = bst.traverse(TreeTraversalOrder.LEVEL_ORDER);
 
-    assertThrows(ConcurrentModificationException.class, () -> {
-      while (iter.hasNext()) {
-        bst.add(0);
-        iter.next();
-      }
-    });
+    assertThrows(
+        ConcurrentModificationException.class,
+        () -> {
+          while (iter.hasNext()) {
+            bst.add(0);
+            iter.next();
+          }
+        });
   }
 
   @Test
@@ -290,12 +297,14 @@ public class BinarySearchTreeTest {
 
     Iterator<Integer> iter = bst.traverse(TreeTraversalOrder.PRE_ORDER);
 
-    assertThrows(ConcurrentModificationException.class, () -> {
-      while (iter.hasNext()) {
-        bst.remove(2);
-        iter.next();
-      }
-    });
+    assertThrows(
+        ConcurrentModificationException.class,
+        () -> {
+          while (iter.hasNext()) {
+            bst.remove(2);
+            iter.next();
+          }
+        });
   }
 
   @Test
@@ -309,12 +318,14 @@ public class BinarySearchTreeTest {
 
     Iterator<Integer> iter = bst.traverse(TreeTraversalOrder.IN_ORDER);
 
-    assertThrows(ConcurrentModificationException.class, () -> {
-      while (iter.hasNext()) {
-        bst.remove(2);
-        iter.next();
-      }
-    });
+    assertThrows(
+        ConcurrentModificationException.class,
+        () -> {
+          while (iter.hasNext()) {
+            bst.remove(2);
+            iter.next();
+          }
+        });
   }
 
   @Test
@@ -328,12 +339,14 @@ public class BinarySearchTreeTest {
 
     Iterator<Integer> iter = bst.traverse(TreeTraversalOrder.POST_ORDER);
 
-    assertThrows(ConcurrentModificationException.class, () -> {
-      while (iter.hasNext()) {
-        bst.remove(2);
-        iter.next();
-      }
-    });
+    assertThrows(
+        ConcurrentModificationException.class,
+        () -> {
+          while (iter.hasNext()) {
+            bst.remove(2);
+            iter.next();
+          }
+        });
   }
 
   @Test
@@ -347,12 +360,14 @@ public class BinarySearchTreeTest {
 
     Iterator<Integer> iter = bst.traverse(TreeTraversalOrder.LEVEL_ORDER);
 
-    assertThrows(ConcurrentModificationException.class, () -> {
-      while (iter.hasNext()) {
-        bst.remove(2);
-        iter.next();
-      }
-    });
+    assertThrows(
+        ConcurrentModificationException.class,
+        () -> {
+          while (iter.hasNext()) {
+            bst.remove(2);
+            iter.next();
+          }
+        });
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/binarysearchtree/BinarySearchTreeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/binarysearchtree/BinarySearchTreeTest.java
@@ -1,6 +1,7 @@
 package com.williamfiset.algorithms.datastructures.binarysearchtree;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -9,8 +10,8 @@ import java.util.ConcurrentModificationException;
 import java.util.Deque;
 import java.util.Iterator;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.api.*;
 
 class TestTreeNode {
 
@@ -84,7 +85,7 @@ public class BinarySearchTreeTest {
 
   static final int LOOPS = 100;
 
-  @Before
+  @BeforeEach
   public void setup() {}
 
   @Test
@@ -202,7 +203,7 @@ public class BinarySearchTreeTest {
     assertThat(tree.contains('C')).isTrue();
   }
 
-  @Test(expected = ConcurrentModificationException.class)
+  @Test
   public void concurrentModificationErrorPreOrder() {
 
     BinarySearchTree<Integer> bst = new BinarySearchTree<>();
@@ -213,13 +214,15 @@ public class BinarySearchTreeTest {
 
     Iterator<Integer> iter = bst.traverse(TreeTraversalOrder.PRE_ORDER);
 
-    while (iter.hasNext()) {
-      bst.add(0);
-      iter.next();
-    }
+    assertThrows(ConcurrentModificationException.class, () -> {
+      while (iter.hasNext()) {
+        bst.add(0);
+        iter.next();
+      }
+    });
   }
 
-  @Test(expected = ConcurrentModificationException.class)
+  @Test
   public void concurrentModificationErrorInOrderOrder() {
 
     BinarySearchTree<Integer> bst = new BinarySearchTree<>();
@@ -230,13 +233,15 @@ public class BinarySearchTreeTest {
 
     Iterator<Integer> iter = bst.traverse(TreeTraversalOrder.IN_ORDER);
 
-    while (iter.hasNext()) {
-      bst.add(0);
-      iter.next();
-    }
+    assertThrows(ConcurrentModificationException.class, () -> {
+      while (iter.hasNext()) {
+        bst.add(0);
+        iter.next();
+      }
+    });
   }
 
-  @Test(expected = ConcurrentModificationException.class)
+  @Test
   public void concurrentModificationErrorPostOrder() {
 
     BinarySearchTree<Integer> bst = new BinarySearchTree<>();
@@ -247,13 +252,15 @@ public class BinarySearchTreeTest {
 
     Iterator<Integer> iter = bst.traverse(TreeTraversalOrder.POST_ORDER);
 
-    while (iter.hasNext()) {
-      bst.add(0);
-      iter.next();
-    }
+    assertThrows(ConcurrentModificationException.class, () -> {
+      while (iter.hasNext()) {
+        bst.add(0);
+        iter.next();
+      }
+    });
   }
 
-  @Test(expected = ConcurrentModificationException.class)
+  @Test
   public void concurrentModificationErrorLevelOrder() {
 
     BinarySearchTree<Integer> bst = new BinarySearchTree<>();
@@ -264,13 +271,15 @@ public class BinarySearchTreeTest {
 
     Iterator<Integer> iter = bst.traverse(TreeTraversalOrder.LEVEL_ORDER);
 
-    while (iter.hasNext()) {
-      bst.add(0);
-      iter.next();
-    }
+    assertThrows(ConcurrentModificationException.class, () -> {
+      while (iter.hasNext()) {
+        bst.add(0);
+        iter.next();
+      }
+    });
   }
 
-  @Test(expected = ConcurrentModificationException.class)
+  @Test
   public void concurrentModificationErrorRemovingPreOrder() {
 
     BinarySearchTree<Integer> bst = new BinarySearchTree<>();
@@ -281,13 +290,15 @@ public class BinarySearchTreeTest {
 
     Iterator<Integer> iter = bst.traverse(TreeTraversalOrder.PRE_ORDER);
 
-    while (iter.hasNext()) {
-      bst.remove(2);
-      iter.next();
-    }
+    assertThrows(ConcurrentModificationException.class, () -> {
+      while (iter.hasNext()) {
+        bst.remove(2);
+        iter.next();
+      }
+    });
   }
 
-  @Test(expected = ConcurrentModificationException.class)
+  @Test
   public void concurrentModificationErrorRemovingInOrderOrder() {
 
     BinarySearchTree<Integer> bst = new BinarySearchTree<>();
@@ -298,13 +309,15 @@ public class BinarySearchTreeTest {
 
     Iterator<Integer> iter = bst.traverse(TreeTraversalOrder.IN_ORDER);
 
-    while (iter.hasNext()) {
-      bst.remove(2);
-      iter.next();
-    }
+    assertThrows(ConcurrentModificationException.class, () -> {
+      while (iter.hasNext()) {
+        bst.remove(2);
+        iter.next();
+      }
+    });
   }
 
-  @Test(expected = ConcurrentModificationException.class)
+  @Test
   public void concurrentModificationErrorRemovingPostOrder() {
 
     BinarySearchTree<Integer> bst = new BinarySearchTree<>();
@@ -315,13 +328,15 @@ public class BinarySearchTreeTest {
 
     Iterator<Integer> iter = bst.traverse(TreeTraversalOrder.POST_ORDER);
 
-    while (iter.hasNext()) {
-      bst.remove(2);
-      iter.next();
-    }
+    assertThrows(ConcurrentModificationException.class, () -> {
+      while (iter.hasNext()) {
+        bst.remove(2);
+        iter.next();
+      }
+    });
   }
 
-  @Test(expected = ConcurrentModificationException.class)
+  @Test
   public void concurrentModificationErrorRemovingLevelOrder() {
 
     BinarySearchTree<Integer> bst = new BinarySearchTree<>();
@@ -332,10 +347,12 @@ public class BinarySearchTreeTest {
 
     Iterator<Integer> iter = bst.traverse(TreeTraversalOrder.LEVEL_ORDER);
 
-    while (iter.hasNext()) {
-      bst.remove(2);
-      iter.next();
-    }
+    assertThrows(ConcurrentModificationException.class, () -> {
+      while (iter.hasNext()) {
+        bst.remove(2);
+        iter.next();
+      }
+    });
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/binarysearchtree/SplayTreeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/binarysearchtree/SplayTreeTest.java
@@ -4,7 +4,8 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.williamfiset.algorithms.datastructures.utils.TestUtils;
 import java.util.*;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 public class SplayTreeTest {
 

--- a/src/test/java/com/williamfiset/algorithms/datastructures/binarysearchtree/SplayTreeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/binarysearchtree/SplayTreeTest.java
@@ -4,7 +4,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.williamfiset.algorithms.datastructures.utils.TestUtils;
 import java.util.*;
-
 import org.junit.jupiter.api.Test;
 
 public class SplayTreeTest {

--- a/src/test/java/com/williamfiset/algorithms/datastructures/bloomfilter/BloomFilterTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/bloomfilter/BloomFilterTest.java
@@ -6,7 +6,6 @@ import java.security.SecureRandom;
 import java.util.HashSet;
 import java.util.Random;
 import java.util.Set;
-
 import org.junit.jupiter.api.*;
 
 public class BloomFilterTest {

--- a/src/test/java/com/williamfiset/algorithms/datastructures/bloomfilter/BloomFilterTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/bloomfilter/BloomFilterTest.java
@@ -6,8 +6,8 @@ import java.security.SecureRandom;
 import java.util.HashSet;
 import java.util.Random;
 import java.util.Set;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.api.*;
 
 public class BloomFilterTest {
 
@@ -20,7 +20,7 @@ public class BloomFilterTest {
   static final int TEST_SZ = 1000;
   static final int LOOPS = 1000;
 
-  @Before
+  @BeforeEach
   public void setup() {}
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/fenwicktree/FenwickTreeRangeQueryPointUpdateTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/fenwicktree/FenwickTreeRangeQueryPointUpdateTest.java
@@ -1,9 +1,9 @@
 package com.williamfiset.algorithms.datastructures.fenwicktree;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
 
 public class FenwickTreeRangeQueryPointUpdateTest {
 
@@ -15,7 +15,7 @@ public class FenwickTreeRangeQueryPointUpdateTest {
 
   static long UNUSED_VAL;
 
-  @Before
+  @BeforeEach
   public void setup() {
     UNUSED_VAL = randValue();
   }
@@ -169,9 +169,9 @@ public class FenwickTreeRangeQueryPointUpdateTest {
     return (long) (Math.random() * MAX_RAND_NUM * 2) + MIN_RAND_NUM;
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testIllegalCreation() {
-    new FenwickTreeRangeQueryPointUpdate(null);
+    assertThrows(IllegalArgumentException.class, () -> new FenwickTreeRangeQueryPointUpdate(null));
   }
 
   // Generate a list of random numbers, one based

--- a/src/test/java/com/williamfiset/algorithms/datastructures/fenwicktree/FenwickTreeRangeUpdatePointQueryTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/fenwicktree/FenwickTreeRangeUpdatePointQueryTest.java
@@ -1,9 +1,9 @@
 package com.williamfiset.algorithms.datastructures.fenwicktree;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
 
 public class FenwickTreeRangeUpdatePointQueryTest {
 
@@ -31,14 +31,14 @@ public class FenwickTreeRangeUpdatePointQueryTest {
 
   static long UNUSED_VAL;
 
-  @Before
+  @BeforeEach
   public void setup() {
     UNUSED_VAL = randValue();
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testIllegalCreation() {
-    new FenwickTreeRangeUpdatePointQuery(null);
+    assertThrows(IllegalArgumentException.class, () -> new FenwickTreeRangeUpdatePointQuery(null));
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/fibonacciheap/FibonacciHeapTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/fibonacciheap/FibonacciHeapTest.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Queue;
 import java.util.Random;
-
 import org.junit.jupiter.api.*;
 
 // Disclaimer: Based by help of

--- a/src/test/java/com/williamfiset/algorithms/datastructures/fibonacciheap/FibonacciHeapTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/fibonacciheap/FibonacciHeapTest.java
@@ -2,6 +2,7 @@ package com.williamfiset.algorithms.datastructures.fibonacciheap;
 
 import static com.google.common.truth.Truth.assertThat;
 import static java.util.Collections.sort;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -9,9 +10,8 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Queue;
 import java.util.Random;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.api.*;
 
 // Disclaimer: Based by help of
 // "http://langrsoft.com/jeff/2011/11/test-driving-a-heap-based-priority-queue/">Test-Driving a
@@ -22,12 +22,12 @@ public final class FibonacciHeapTest {
 
   private Queue<Integer> queue;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     queue = new FibonacciHeap<Integer>();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     queue = null;
   }
@@ -157,8 +157,8 @@ public final class FibonacciHeapTest {
     assertThat(queue.size()).isEqualTo(4);
   }
 
-  @Test(expected = NoSuchElementException.class)
+  @Test
   public void elementThrowsException() {
-    queue.element();
+    assertThrows(NoSuchElementException.class, () -> queue.element());
   }
 }

--- a/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableDoubleHashingTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableDoubleHashingTest.java
@@ -1,9 +1,11 @@
 package com.williamfiset.algorithms.datastructures.hashtable;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.*;
-import org.junit.*;
+
+import org.junit.jupiter.api.*;
 
 public class HashTableDoubleHashingTest {
 
@@ -18,35 +20,30 @@ public class HashTableDoubleHashingTest {
 
   HashTableDoubleHashing<DoubleHashingTestObject, Integer> map;
 
-  @Before
+  @BeforeEach
   public void setup() {
     map = new HashTableDoubleHashing<>();
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testNullKey() {
-    map.put(null, 5);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testIllegalCreation1() {
-    new HashTableDoubleHashing<>(-3, 0.5);
+    assertThrows(IllegalArgumentException.class, () -> new HashTableDoubleHashing<>(-3, 0.5));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testIllegalCreation2() {
-    new HashTableDoubleHashing<>(5, Double.POSITIVE_INFINITY);
+    assertThrows(IllegalArgumentException.class, () -> new HashTableDoubleHashing<>(5, Double.POSITIVE_INFINITY));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testIllegalCreation3() {
-    new HashTableDoubleHashing<>(6, -0.5);
+    assertThrows(IllegalArgumentException.class, () -> new HashTableDoubleHashing<>(6, -0.5));
   }
 
   @Test
   public void testLegalCreation() {
     // System.out.println("testLegalCreation");
-    new HashTableDoubleHashing<>(6, 0.9);
+    assertDoesNotThrow(() -> new HashTableDoubleHashing<>(6, 0.9));
   }
 
   @Test
@@ -107,28 +104,32 @@ public class HashTableDoubleHashingTest {
     }
   }
 
-  @Test(expected = java.util.ConcurrentModificationException.class)
+  @Test
   public void testConcurrentModificationException() {
-    // System.out.println("testConcurrentModificationException");
-    DoubleHashingTestObject o1 = new DoubleHashingTestObject(1);
-    DoubleHashingTestObject o2 = new DoubleHashingTestObject(2);
-    DoubleHashingTestObject o3 = new DoubleHashingTestObject(3);
-    DoubleHashingTestObject o4 = new DoubleHashingTestObject(4);
-    map.add(o1, 1);
-    map.add(o2, 1);
-    map.add(o3, 1);
-    for (DoubleHashingTestObject key : map) map.add(o4, 4);
+    assertThrows(ConcurrentModificationException.class, () -> {
+      // System.out.println("testConcurrentModificationException");
+      DoubleHashingTestObject o1 = new DoubleHashingTestObject(1);
+      DoubleHashingTestObject o2 = new DoubleHashingTestObject(2);
+      DoubleHashingTestObject o3 = new DoubleHashingTestObject(3);
+      DoubleHashingTestObject o4 = new DoubleHashingTestObject(4);
+      map.add(o1, 1);
+      map.add(o2, 1);
+      map.add(o3, 1);
+      for (DoubleHashingTestObject key : map) map.add(o4, 4);
+    });
   }
 
-  @Test(expected = java.util.ConcurrentModificationException.class)
+  @Test
   public void testConcurrentModificationException2() {
-    DoubleHashingTestObject o1 = new DoubleHashingTestObject(1);
-    DoubleHashingTestObject o2 = new DoubleHashingTestObject(2);
-    DoubleHashingTestObject o3 = new DoubleHashingTestObject(3);
-    map.add(o1, 1);
-    map.add(o2, 1);
-    map.add(o3, 1);
-    for (DoubleHashingTestObject key : map) map.remove(o2);
+    assertThrows(ConcurrentModificationException.class, () -> {
+      DoubleHashingTestObject o1 = new DoubleHashingTestObject(1);
+      DoubleHashingTestObject o2 = new DoubleHashingTestObject(2);
+      DoubleHashingTestObject o3 = new DoubleHashingTestObject(3);
+      map.add(o1, 1);
+      map.add(o2, 1);
+      map.add(o3, 1);
+      for (DoubleHashingTestObject key : map) map.remove(o2);
+    });
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableDoubleHashingTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableDoubleHashingTest.java
@@ -4,7 +4,6 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.*;
-
 import org.junit.jupiter.api.*;
 
 public class HashTableDoubleHashingTest {
@@ -32,7 +31,9 @@ public class HashTableDoubleHashingTest {
 
   @Test
   public void testIllegalCreation2() {
-    assertThrows(IllegalArgumentException.class, () -> new HashTableDoubleHashing<>(5, Double.POSITIVE_INFINITY));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new HashTableDoubleHashing<>(5, Double.POSITIVE_INFINITY));
   }
 
   @Test
@@ -106,30 +107,34 @@ public class HashTableDoubleHashingTest {
 
   @Test
   public void testConcurrentModificationException() {
-    assertThrows(ConcurrentModificationException.class, () -> {
-      // System.out.println("testConcurrentModificationException");
-      DoubleHashingTestObject o1 = new DoubleHashingTestObject(1);
-      DoubleHashingTestObject o2 = new DoubleHashingTestObject(2);
-      DoubleHashingTestObject o3 = new DoubleHashingTestObject(3);
-      DoubleHashingTestObject o4 = new DoubleHashingTestObject(4);
-      map.add(o1, 1);
-      map.add(o2, 1);
-      map.add(o3, 1);
-      for (DoubleHashingTestObject key : map) map.add(o4, 4);
-    });
+    assertThrows(
+        ConcurrentModificationException.class,
+        () -> {
+          // System.out.println("testConcurrentModificationException");
+          DoubleHashingTestObject o1 = new DoubleHashingTestObject(1);
+          DoubleHashingTestObject o2 = new DoubleHashingTestObject(2);
+          DoubleHashingTestObject o3 = new DoubleHashingTestObject(3);
+          DoubleHashingTestObject o4 = new DoubleHashingTestObject(4);
+          map.add(o1, 1);
+          map.add(o2, 1);
+          map.add(o3, 1);
+          for (DoubleHashingTestObject key : map) map.add(o4, 4);
+        });
   }
 
   @Test
   public void testConcurrentModificationException2() {
-    assertThrows(ConcurrentModificationException.class, () -> {
-      DoubleHashingTestObject o1 = new DoubleHashingTestObject(1);
-      DoubleHashingTestObject o2 = new DoubleHashingTestObject(2);
-      DoubleHashingTestObject o3 = new DoubleHashingTestObject(3);
-      map.add(o1, 1);
-      map.add(o2, 1);
-      map.add(o3, 1);
-      for (DoubleHashingTestObject key : map) map.remove(o2);
-    });
+    assertThrows(
+        ConcurrentModificationException.class,
+        () -> {
+          DoubleHashingTestObject o1 = new DoubleHashingTestObject(1);
+          DoubleHashingTestObject o2 = new DoubleHashingTestObject(2);
+          DoubleHashingTestObject o3 = new DoubleHashingTestObject(3);
+          map.add(o1, 1);
+          map.add(o2, 1);
+          map.add(o3, 1);
+          for (DoubleHashingTestObject key : map) map.remove(o2);
+        });
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableLinearProbingTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableLinearProbingTest.java
@@ -1,9 +1,11 @@
 package com.williamfiset.algorithms.datastructures.hashtable;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.*;
-import org.junit.*;
+
+import org.junit.jupiter.api.*;
 
 public class HashTableLinearProbingTest {
 
@@ -40,34 +42,34 @@ public class HashTableLinearProbingTest {
 
   HashTableLinearProbing<Integer, Integer> map;
 
-  @Before
+  @BeforeEach
   public void setup() {
     map = new HashTableLinearProbing<>();
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testNullKey() {
-    map.put(null, 5);
+    assertThrows(IllegalArgumentException.class, () -> map.put(null, 5));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testIllegalCreation1() {
-    new HashTableLinearProbing<>(-3, 0.5);
+    assertThrows(IllegalArgumentException.class, () -> new HashTableLinearProbing<>(-3, 0.5));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testIllegalCreation2() {
-    new HashTableLinearProbing<>(5, Double.POSITIVE_INFINITY);
+    assertThrows(IllegalArgumentException.class, () -> new HashTableLinearProbing<>(5, Double.POSITIVE_INFINITY));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testIllegalCreation3() {
-    new HashTableLinearProbing<>(6, -0.5);
+    assertThrows(IllegalArgumentException.class, () -> new HashTableLinearProbing<>(6, -0.5));
   }
 
   @Test
   public void testLegalCreation() {
-    new HashTableLinearProbing<>(6, 0.9);
+    assertDoesNotThrow(() -> new HashTableLinearProbing<>(6, 0.9));
   }
 
   @Test
@@ -120,20 +122,24 @@ public class HashTableLinearProbingTest {
     }
   }
 
-  @Test(expected = java.util.ConcurrentModificationException.class)
+  @Test
   public void testConcurrentModificationException() {
-    map.add(1, 1);
-    map.add(2, 1);
-    map.add(3, 1);
-    for (Integer key : map) map.add(4, 4);
+    assertThrows(ConcurrentModificationException.class, () -> {
+      map.add(1, 1);
+      map.add(2, 1);
+      map.add(3, 1);
+      for (Integer key : map) map.add(4, 4);
+    });
   }
 
-  @Test(expected = java.util.ConcurrentModificationException.class)
+  @Test
   public void testConcurrentModificationException2() {
-    map.add(1, 1);
-    map.add(2, 1);
-    map.add(3, 1);
-    for (Integer key : map) map.remove(2);
+    assertThrows(ConcurrentModificationException.class, () -> {
+      map.add(1, 1);
+      map.add(2, 1);
+      map.add(3, 1);
+      for (Integer key : map) map.remove(2);
+    });
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableLinearProbingTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableLinearProbingTest.java
@@ -4,7 +4,6 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.*;
-
 import org.junit.jupiter.api.*;
 
 public class HashTableLinearProbingTest {
@@ -59,7 +58,9 @@ public class HashTableLinearProbingTest {
 
   @Test
   public void testIllegalCreation2() {
-    assertThrows(IllegalArgumentException.class, () -> new HashTableLinearProbing<>(5, Double.POSITIVE_INFINITY));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new HashTableLinearProbing<>(5, Double.POSITIVE_INFINITY));
   }
 
   @Test
@@ -124,22 +125,26 @@ public class HashTableLinearProbingTest {
 
   @Test
   public void testConcurrentModificationException() {
-    assertThrows(ConcurrentModificationException.class, () -> {
-      map.add(1, 1);
-      map.add(2, 1);
-      map.add(3, 1);
-      for (Integer key : map) map.add(4, 4);
-    });
+    assertThrows(
+        ConcurrentModificationException.class,
+        () -> {
+          map.add(1, 1);
+          map.add(2, 1);
+          map.add(3, 1);
+          for (Integer key : map) map.add(4, 4);
+        });
   }
 
   @Test
   public void testConcurrentModificationException2() {
-    assertThrows(ConcurrentModificationException.class, () -> {
-      map.add(1, 1);
-      map.add(2, 1);
-      map.add(3, 1);
-      for (Integer key : map) map.remove(2);
-    });
+    assertThrows(
+        ConcurrentModificationException.class,
+        () -> {
+          map.add(1, 1);
+          map.add(2, 1);
+          map.add(3, 1);
+          for (Integer key : map) map.remove(2);
+        });
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableQuadraticProbingTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableQuadraticProbingTest.java
@@ -58,7 +58,9 @@ public class HashTableQuadraticProbingTest {
 
   @Test
   public void testIllegalCreation2() {
-    assertThrows(IllegalArgumentException.class, () -> new HashTableQuadraticProbing<>(5, Double.POSITIVE_INFINITY));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new HashTableQuadraticProbing<>(5, Double.POSITIVE_INFINITY));
   }
 
   @Test
@@ -144,22 +146,26 @@ public class HashTableQuadraticProbingTest {
 
   @Test
   public void testConcurrentModificationException() {
-    assertThrows(ConcurrentModificationException.class, () -> {
-      map.add(1, 1);
-      map.add(2, 1);
-      map.add(3, 1);
-      for (Integer key : map) map.add(4, 4);
-    });
+    assertThrows(
+        ConcurrentModificationException.class,
+        () -> {
+          map.add(1, 1);
+          map.add(2, 1);
+          map.add(3, 1);
+          for (Integer key : map) map.add(4, 4);
+        });
   }
 
   @Test
   public void testConcurrentModificationException2() {
-    assertThrows(ConcurrentModificationException.class, () -> {
-      map.add(1, 1);
-      map.add(2, 1);
-      map.add(3, 1);
-      for (Integer key : map) map.remove(2);
-    });
+    assertThrows(
+        ConcurrentModificationException.class,
+        () -> {
+          map.add(1, 1);
+          map.add(2, 1);
+          map.add(3, 1);
+          for (Integer key : map) map.remove(2);
+        });
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableQuadraticProbingTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableQuadraticProbingTest.java
@@ -1,9 +1,10 @@
 package com.williamfiset.algorithms.datastructures.hashtable;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.*;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 public class HashTableQuadraticProbingTest {
 
@@ -40,34 +41,34 @@ public class HashTableQuadraticProbingTest {
 
   HashTableQuadraticProbing<Integer, Integer> map;
 
-  @Before
+  @BeforeEach
   public void setup() {
     map = new HashTableQuadraticProbing<>();
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testNullKey() {
-    map.put(null, 5);
+    assertThrows(IllegalArgumentException.class, () -> map.put(null, 5));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testIllegalCreation1() {
-    new HashTableQuadraticProbing<>(-3, 0.5);
+    assertThrows(IllegalArgumentException.class, () -> new HashTableQuadraticProbing<>(-3, 0.5));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testIllegalCreation2() {
-    new HashTableQuadraticProbing<>(5, Double.POSITIVE_INFINITY);
+    assertThrows(IllegalArgumentException.class, () -> new HashTableQuadraticProbing<>(5, Double.POSITIVE_INFINITY));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testIllegalCreation3() {
-    new HashTableQuadraticProbing<>(6, -0.5);
+    assertThrows(IllegalArgumentException.class, () -> new HashTableQuadraticProbing<>(6, -0.5));
   }
 
   @Test
   public void testLegalCreation() {
-    new HashTableQuadraticProbing<>(6, 0.9);
+    assertDoesNotThrow(() -> new HashTableQuadraticProbing<>(6, 0.9));
   }
 
   @Test
@@ -141,20 +142,24 @@ public class HashTableQuadraticProbingTest {
     }
   }
 
-  @Test(expected = java.util.ConcurrentModificationException.class)
+  @Test
   public void testConcurrentModificationException() {
-    map.add(1, 1);
-    map.add(2, 1);
-    map.add(3, 1);
-    for (Integer key : map) map.add(4, 4);
+    assertThrows(ConcurrentModificationException.class, () -> {
+      map.add(1, 1);
+      map.add(2, 1);
+      map.add(3, 1);
+      for (Integer key : map) map.add(4, 4);
+    });
   }
 
-  @Test(expected = java.util.ConcurrentModificationException.class)
+  @Test
   public void testConcurrentModificationException2() {
-    map.add(1, 1);
-    map.add(2, 1);
-    map.add(3, 1);
-    for (Integer key : map) map.remove(2);
+    assertThrows(ConcurrentModificationException.class, () -> {
+      map.add(1, 1);
+      map.add(2, 1);
+      map.add(3, 1);
+      for (Integer key : map) map.remove(2);
+    });
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableSeparateChainingTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableSeparateChainingTest.java
@@ -4,7 +4,6 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.*;
-
 import org.junit.jupiter.api.*;
 
 public class HashTableSeparateChainingTest {
@@ -54,7 +53,9 @@ public class HashTableSeparateChainingTest {
 
   @Test
   public void testIllegalCreation2() {
-    assertThrows(IllegalArgumentException.class, () -> new HashTableSeparateChaining<>(5, Double.POSITIVE_INFINITY));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new HashTableSeparateChaining<>(5, Double.POSITIVE_INFINITY));
   }
 
   @Test
@@ -119,22 +120,26 @@ public class HashTableSeparateChainingTest {
 
   @Test
   public void testConcurrentModificationException() {
-    assertThrows(ConcurrentModificationException.class, () -> {
-      map.add(1, 1);
-      map.add(2, 1);
-      map.add(3, 1);
-      for (Integer key : map) map.add(4, 4);
-    });
+    assertThrows(
+        ConcurrentModificationException.class,
+        () -> {
+          map.add(1, 1);
+          map.add(2, 1);
+          map.add(3, 1);
+          for (Integer key : map) map.add(4, 4);
+        });
   }
 
   @Test
   public void testConcurrentModificationException2() {
-    assertThrows(ConcurrentModificationException.class, () -> {
-      map.add(1, 1);
-      map.add(2, 1);
-      map.add(3, 1);
-      for (Integer key : map) map.remove(2);
-    });
+    assertThrows(
+        ConcurrentModificationException.class,
+        () -> {
+          map.add(1, 1);
+          map.add(2, 1);
+          map.add(3, 1);
+          for (Integer key : map) map.remove(2);
+        });
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableSeparateChainingTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableSeparateChainingTest.java
@@ -1,9 +1,11 @@
 package com.williamfiset.algorithms.datastructures.hashtable;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.*;
-import org.junit.*;
+
+import org.junit.jupiter.api.*;
 
 public class HashTableSeparateChainingTest {
 
@@ -40,34 +42,29 @@ public class HashTableSeparateChainingTest {
 
   HashTableSeparateChaining<Integer, Integer> map;
 
-  @Before
+  @BeforeEach
   public void setup() {
     map = new HashTableSeparateChaining<>();
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testNullKey() {
-    map.put(null, 5);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testIllegalCreation1() {
-    new HashTableSeparateChaining<>(-3, 0.5);
+    assertThrows(IllegalArgumentException.class, () -> new HashTableSeparateChaining<>(-3, 0.5));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testIllegalCreation2() {
-    new HashTableSeparateChaining<>(5, Double.POSITIVE_INFINITY);
+    assertThrows(IllegalArgumentException.class, () -> new HashTableSeparateChaining<>(5, Double.POSITIVE_INFINITY));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testIllegalCreation3() {
-    new HashTableSeparateChaining<>(6, -0.5);
+    assertThrows(IllegalArgumentException.class, () -> new HashTableSeparateChaining<>(6, -0.5));
   }
 
   @Test
   public void testLegalCreation() {
-    new HashTableSeparateChaining<>(6, 0.9);
+    assertDoesNotThrow(() -> new HashTableSeparateChaining<>(6, 0.9));
   }
 
   @Test
@@ -120,20 +117,24 @@ public class HashTableSeparateChainingTest {
     }
   }
 
-  @Test(expected = java.util.ConcurrentModificationException.class)
+  @Test
   public void testConcurrentModificationException() {
-    map.add(1, 1);
-    map.add(2, 1);
-    map.add(3, 1);
-    for (Integer key : map) map.add(4, 4);
+    assertThrows(ConcurrentModificationException.class, () -> {
+      map.add(1, 1);
+      map.add(2, 1);
+      map.add(3, 1);
+      for (Integer key : map) map.add(4, 4);
+    });
   }
 
-  @Test(expected = java.util.ConcurrentModificationException.class)
+  @Test
   public void testConcurrentModificationException2() {
-    map.add(1, 1);
-    map.add(2, 1);
-    map.add(3, 1);
-    for (Integer key : map) map.remove(2);
+    assertThrows(ConcurrentModificationException.class, () -> {
+      map.add(1, 1);
+      map.add(2, 1);
+      map.add(3, 1);
+      for (Integer key : map) map.remove(2);
+    });
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/kdtree/GeneralKDTreeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/kdtree/GeneralKDTreeTest.java
@@ -1,20 +1,21 @@
 package com.williamfiset.algorithms.datastructures.kdtree;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class GeneralKDTreeTest {
 
   /* TREE CREATION TESTS */
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testDimensionsZero() {
-    new GeneralKDTree<>(0);
+    assertThrows(IllegalArgumentException.class, () -> new GeneralKDTree<>(0));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testDimensionsNegative() {
-    new GeneralKDTree<>(-5);
+    assertThrows(IllegalArgumentException.class, () -> new GeneralKDTree<>(-5));
   }
 
   /* INSERT METHOD TESTS */
@@ -32,16 +33,16 @@ public class GeneralKDTreeTest {
     assertThat(kdTree.getRootPoint() == pointRoot).isTrue();
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testInsertNull() {
     GeneralKDTree<Integer> kdTree = new GeneralKDTree<Integer>(2);
-    kdTree.insert(null);
+    assertThrows(IllegalArgumentException.class, () -> kdTree.insert(null));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testInsertMismatchDimensions() {
     GeneralKDTree<Integer> kdTree = new GeneralKDTree<Integer>(2);
-    kdTree.insert(new Integer[] {1, 2, 3});
+    assertThrows(IllegalArgumentException.class, () -> kdTree.insert(new Integer[] {1, 2, 3}));
   }
 
   /* SEARCH METHOD TESTS */
@@ -64,16 +65,16 @@ public class GeneralKDTreeTest {
     assertThat(kdTree.search(new Integer[] {7, 5, 4, 9})).isFalse();
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testSearchNull() {
     GeneralKDTree<Integer> kdTree = new GeneralKDTree<Integer>(2);
-    kdTree.search(null);
+    assertThrows(IllegalArgumentException.class, () -> kdTree.search(null));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testSearchMismatchDimensions() {
     GeneralKDTree<Integer> kdTree = new GeneralKDTree<Integer>(2);
-    kdTree.search(new Integer[] {1, 2, 3});
+    assertThrows(IllegalArgumentException.class, () -> kdTree.search(new Integer[] {1, 2, 3}));
   }
 
   /* FINDMIN METHOD TESTS */
@@ -97,16 +98,16 @@ public class GeneralKDTreeTest {
     assertThat(kdTree.findMin(2) == min3).isTrue();
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testFindMinOutOfBounds() {
     GeneralKDTree<Integer> kdTree = new GeneralKDTree<Integer>(2);
-    kdTree.findMin(2);
+    assertThrows(IllegalArgumentException.class, () -> kdTree.findMin(2));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testFindMinNegative() {
     GeneralKDTree<Integer> kdTree = new GeneralKDTree<Integer>(2);
-    kdTree.findMin(-1);
+    assertThrows(IllegalArgumentException.class, () -> kdTree.findMin(-1));
   }
 
   /* DELETE METHOD TESTS */
@@ -172,15 +173,15 @@ public class GeneralKDTreeTest {
     assertThat(kdTree.delete(point8) == null).isTrue();
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testDeleteNull() {
     GeneralKDTree<Integer> kdTree = new GeneralKDTree<Integer>(2);
-    kdTree.delete(null);
+    assertThrows(IllegalArgumentException.class, () -> kdTree.delete(null));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testDeleteMismatchDimensions() {
     GeneralKDTree<Integer> kdTree = new GeneralKDTree<Integer>(2);
-    kdTree.delete(new Integer[] {1, 2, 3});
+    assertThrows(IllegalArgumentException.class, () -> kdTree.delete(new Integer[] {1, 2, 3}));
   }
 }

--- a/src/test/java/com/williamfiset/algorithms/datastructures/linkedlist/LinkedListTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/linkedlist/LinkedListTest.java
@@ -1,11 +1,13 @@
 package com.williamfiset.algorithms.datastructures.linkedlist;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import org.junit.*;
+
+import org.junit.jupiter.api.*;
 
 public class LinkedListTest {
   private static final int LOOPS = 10000;
@@ -15,7 +17,7 @@ public class LinkedListTest {
 
   DoublyLinkedList<Integer> list;
 
-  @Before
+  @BeforeEach
   public void setup() {
     list = new DoublyLinkedList<>();
   }
@@ -26,24 +28,24 @@ public class LinkedListTest {
     assertThat(list.size()).isEqualTo(0);
   }
 
-  @Test(expected = Exception.class)
+  @Test
   public void testRemoveFirstOfEmpty() {
-    list.removeFirst();
+    assertThrows(Exception.class, () -> list.removeFirst());
   }
 
-  @Test(expected = Exception.class)
+  @Test
   public void testRemoveLastOfEmpty() {
-    list.removeLast();
+    assertThrows(Exception.class, () -> list.removeLast());
   }
 
-  @Test(expected = Exception.class)
+  @Test
   public void testPeekFirstOfEmpty() {
-    list.peekFirst();
+    assertThrows(Exception.class, () -> list.peekFirst());
   }
 
-  @Test(expected = Exception.class)
+  @Test
   public void testPeekLastOfEmpty() {
-    list.peekLast();
+    assertThrows(Exception.class, () -> list.peekLast());
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/linkedlist/LinkedListTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/linkedlist/LinkedListTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
 import org.junit.jupiter.api.*;
 
 public class LinkedListTest {

--- a/src/test/java/com/williamfiset/algorithms/datastructures/priorityqueue/BinaryHeapQuickRemovalsTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/priorityqueue/BinaryHeapQuickRemovalsTest.java
@@ -6,14 +6,15 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.PriorityQueue;
-import org.junit.*;
+
+import org.junit.jupiter.api.*;
 
 public class BinaryHeapQuickRemovalsTest {
 
   static final int LOOPS = 100;
   static final int MAX_SZ = 100;
 
-  @Before
+  @BeforeEach
   public void setup() {}
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/priorityqueue/BinaryHeapQuickRemovalsTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/priorityqueue/BinaryHeapQuickRemovalsTest.java
@@ -6,7 +6,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.PriorityQueue;
-
 import org.junit.jupiter.api.*;
 
 public class BinaryHeapQuickRemovalsTest {

--- a/src/test/java/com/williamfiset/algorithms/datastructures/priorityqueue/BinaryHeapTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/priorityqueue/BinaryHeapTest.java
@@ -6,14 +6,15 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.PriorityQueue;
-import org.junit.*;
+
+import org.junit.jupiter.api.*;
 
 public class BinaryHeapTest {
 
   static final int LOOPS = 100;
   static final int MAX_SZ = 100;
 
-  @Before
+  @BeforeEach
   public void setup() {}
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/priorityqueue/BinaryHeapTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/priorityqueue/BinaryHeapTest.java
@@ -6,7 +6,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.PriorityQueue;
-
 import org.junit.jupiter.api.*;
 
 public class BinaryHeapTest {

--- a/src/test/java/com/williamfiset/algorithms/datastructures/priorityqueue/MinDHeapTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/priorityqueue/MinDHeapTest.java
@@ -6,7 +6,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.PriorityQueue;
-
 import org.junit.jupiter.api.*;
 
 public class MinDHeapTest {

--- a/src/test/java/com/williamfiset/algorithms/datastructures/priorityqueue/MinDHeapTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/priorityqueue/MinDHeapTest.java
@@ -6,15 +6,15 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.PriorityQueue;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.api.*;
 
 public class MinDHeapTest {
 
   static final int LOOPS = 1000;
   static final int MAX_SZ = 100;
 
-  @Before
+  @BeforeEach
   public void setup() {}
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/priorityqueue/MinIndexedBinaryHeapTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/priorityqueue/MinIndexedBinaryHeapTest.java
@@ -10,7 +10,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.PriorityQueue;
 import java.util.Random;
-
 import org.junit.jupiter.api.*;
 
 public class MinIndexedBinaryHeapTest {
@@ -49,11 +48,13 @@ public class MinIndexedBinaryHeapTest {
 
   @Test
   public void testDuplicateKeys() {
-    assertThrows(IllegalArgumentException.class, () -> {
-      MinIndexedBinaryHeap<String> pq = new MinIndexedBinaryHeap<String>(10);
-      pq.insert(5, "abcdef");
-      pq.insert(5, "xyz");
-    });
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          MinIndexedBinaryHeap<String> pq = new MinIndexedBinaryHeap<String>(10);
+          pq.insert(5, "abcdef");
+          pq.insert(5, "xyz");
+        });
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/priorityqueue/MinIndexedBinaryHeapTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/priorityqueue/MinIndexedBinaryHeapTest.java
@@ -1,6 +1,7 @@
 package com.williamfiset.algorithms.datastructures.priorityqueue;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -9,21 +10,22 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.PriorityQueue;
 import java.util.Random;
-import org.junit.*;
+
+import org.junit.jupiter.api.*;
 
 public class MinIndexedBinaryHeapTest {
 
-  @Before
+  @BeforeEach
   public void setup() {}
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testIllegalSizeOfNegativeOne() {
-    new MinIndexedBinaryHeap<String>(-1);
+    assertThrows(IllegalArgumentException.class, () -> new MinIndexedBinaryHeap<String>(-1));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testIllegalSizeOfZero() {
-    new MinIndexedBinaryHeap<String>(0);
+    assertThrows(IllegalArgumentException.class, () -> new MinIndexedBinaryHeap<String>(0));
   }
 
   @Test
@@ -45,11 +47,13 @@ public class MinIndexedBinaryHeapTest {
     assertThat(pq.contains(3)).isFalse();
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testDuplicateKeys() {
-    MinIndexedBinaryHeap<String> pq = new MinIndexedBinaryHeap<String>(10);
-    pq.insert(5, "abcdef");
-    pq.insert(5, "xyz");
+    assertThrows(IllegalArgumentException.class, () -> {
+      MinIndexedBinaryHeap<String> pq = new MinIndexedBinaryHeap<String>(10);
+      pq.insert(5, "abcdef");
+      pq.insert(5, "xyz");
+    });
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/quadtree/QuadTreeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/quadtree/QuadTreeTest.java
@@ -2,8 +2,7 @@ package com.williamfiset.algorithms.datastructures.quadtree;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
 
 public class QuadTreeTest {
 
@@ -11,7 +10,7 @@ public class QuadTreeTest {
   static final int TEST_SZ = 1000;
   static final int MAX_RAND_NUM = +2000;
 
-  @Before
+  @BeforeEach
   public void setup() {}
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/queue/IntQueueTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/queue/IntQueueTest.java
@@ -3,7 +3,6 @@ package com.williamfiset.algorithms.datastructures.queue;
 import static com.google.common.truth.Truth.assertThat;
 
 import java.util.*;
-
 import org.junit.jupiter.api.*;
 
 public class IntQueueTest {

--- a/src/test/java/com/williamfiset/algorithms/datastructures/queue/IntQueueTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/queue/IntQueueTest.java
@@ -3,12 +3,12 @@ package com.williamfiset.algorithms.datastructures.queue;
 import static com.google.common.truth.Truth.assertThat;
 
 import java.util.*;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.api.*;
 
 public class IntQueueTest {
 
-  @Before
+  @BeforeEach
   public void setup() {}
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/queue/QueueTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/queue/QueueTest.java
@@ -1,88 +1,82 @@
 package com.williamfiset.algorithms.datastructures.queue;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class QueueTest {
 
-  private List<Queue<Integer>> queues = new ArrayList<>();
-
-  @Before
-  public void setup() {
+  private static List<Queue<Integer>> inputs() {
+    List<Queue<Integer>> queues = new ArrayList<>();
     queues.add(new ArrayQueue<Integer>(2));
     queues.add(new LinkedQueue<Integer>());
     queues.add(new IntQueue(2));
+    return queues;
   }
 
-  @Test
-  public void testEmptyQueue() {
-    for (Queue queue : queues) {
-      assertThat(queue.isEmpty()).isTrue();
-      assertThat(queue.size()).isEqualTo(0);
-    }
+  @ParameterizedTest
+  @MethodSource("inputs")
+  public void testEmptyQueue(Queue<Integer> queue) {
+    assertThat(queue.isEmpty()).isTrue();
+    assertThat(queue.size()).isEqualTo(0);
   }
 
-  @Test(expected = Exception.class)
-  public void testPollOnEmpty() {
-    for (Queue queue : queues) {
-      queue.poll();
-    }
+  @ParameterizedTest
+  @MethodSource("inputs")
+  public void testPollOnEmpty(Queue<Integer> queue) {
+    assertThrows(Exception.class, () -> queue.poll());
   }
 
-  @Test(expected = Exception.class)
-  public void testPeekOnEmpty() {
-    for (Queue queue : queues) {
-      queue.peek();
-    }
+  @ParameterizedTest
+  @MethodSource("inputs")
+  public void testPeekOnEmpty(Queue<Integer> queue) {
+    assertThrows(Exception.class, () -> queue.peek());
   }
 
-  @Test
-  public void testOffer() {
-    for (Queue<Integer> queue : queues) {
-      queue.offer(2);
-      assertThat(queue.size()).isEqualTo(1);
-    }
+  @ParameterizedTest
+  @MethodSource("inputs")
+  public void testOffer(Queue<Integer> queue) {
+    queue.offer(2);
+    assertThat(queue.size()).isEqualTo(1);
   }
 
-  @Test
-  public void testPeek() {
-    for (Queue<Integer> queue : queues) {
-      queue.offer(2);
-      assertThat((int) queue.peek()).isEqualTo(2);
-      assertThat(queue.size()).isEqualTo(1);
-    }
+  @ParameterizedTest
+  @MethodSource("inputs")
+  public void testPeek(Queue<Integer> queue) {
+    queue.offer(2);
+    assertThat((int) queue.peek()).isEqualTo(2);
+    assertThat(queue.size()).isEqualTo(1);
   }
 
-  @Test
-  public void testPoll() {
-    for (Queue<Integer> queue : queues) {
-      queue.offer(2);
-      assertThat((int) queue.poll()).isEqualTo(2);
-      assertThat(queue.size()).isEqualTo(0);
-    }
+  @ParameterizedTest
+  @MethodSource("inputs")
+  public void testPoll(Queue<Integer> queue) {
+    queue.offer(2);
+    assertThat((int) queue.poll()).isEqualTo(2);
+    assertThat(queue.size()).isEqualTo(0);
   }
 
-  @Test
-  public void testExhaustively() {
-    for (Queue<Integer> queue : queues) {
-      assertThat(queue.isEmpty()).isTrue();
-      queue.offer(1);
-      assertThat(queue.isEmpty()).isFalse();
-      queue.offer(2);
-      assertThat(queue.size()).isEqualTo(2);
-      assertThat((int) queue.peek()).isEqualTo(1);
-      assertThat(queue.size()).isEqualTo(2);
-      assertThat((int) queue.poll()).isEqualTo(1);
-      assertThat(queue.size()).isEqualTo(1);
-      assertThat((int) queue.peek()).isEqualTo(2);
-      assertThat(queue.size()).isEqualTo(1);
-      assertThat((int) queue.poll()).isEqualTo(2);
-      assertThat(queue.size()).isEqualTo(0);
-      assertThat(queue.isEmpty()).isTrue();
-    }
+  @ParameterizedTest
+  @MethodSource("inputs")
+  public void testExhaustively(Queue<Integer> queue) {
+    assertThat(queue.isEmpty()).isTrue();
+    queue.offer(1);
+    assertThat(queue.isEmpty()).isFalse();
+    queue.offer(2);
+    assertThat(queue.size()).isEqualTo(2);
+    assertThat((int) queue.peek()).isEqualTo(1);
+    assertThat(queue.size()).isEqualTo(2);
+    assertThat((int) queue.poll()).isEqualTo(1);
+    assertThat(queue.size()).isEqualTo(1);
+    assertThat((int) queue.peek()).isEqualTo(2);
+    assertThat(queue.size()).isEqualTo(1);
+    assertThat((int) queue.poll()).isEqualTo(2);
+    assertThat(queue.size()).isEqualTo(0);
+    assertThat(queue.isEmpty()).isTrue();
   }
 }

--- a/src/test/java/com/williamfiset/algorithms/datastructures/queue/QueueTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/queue/QueueTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
 import java.util.List;
-
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 

--- a/src/test/java/com/williamfiset/algorithms/datastructures/segmenttree/GenericSegmentTree2Test.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/segmenttree/GenericSegmentTree2Test.java
@@ -7,7 +7,6 @@ package com.williamfiset.algorithms.datastructures.segmenttree;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.williamfiset.algorithms.utils.TestUtils;
-
 import org.junit.jupiter.api.*;
 
 public class GenericSegmentTree2Test {

--- a/src/test/java/com/williamfiset/algorithms/datastructures/segmenttree/GenericSegmentTree2Test.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/segmenttree/GenericSegmentTree2Test.java
@@ -7,15 +7,15 @@ package com.williamfiset.algorithms.datastructures.segmenttree;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.williamfiset.algorithms.utils.TestUtils;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.api.*;
 
 public class GenericSegmentTree2Test {
 
   static int ITERATIONS = 100;
   static int MAX_N = 28;
 
-  @Before
+  @BeforeEach
   public void setup() {}
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/segmenttree/GenericSegmentTreeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/segmenttree/GenericSegmentTreeTest.java
@@ -7,7 +7,6 @@ package com.williamfiset.algorithms.datastructures.segmenttree;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.williamfiset.algorithms.utils.TestUtils;
-
 import org.junit.jupiter.api.Test;
 
 public class GenericSegmentTreeTest {

--- a/src/test/java/com/williamfiset/algorithms/datastructures/segmenttree/GenericSegmentTreeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/segmenttree/GenericSegmentTreeTest.java
@@ -7,7 +7,8 @@ package com.williamfiset.algorithms.datastructures.segmenttree;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.williamfiset.algorithms.utils.TestUtils;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 public class GenericSegmentTreeTest {
 

--- a/src/test/java/com/williamfiset/algorithms/datastructures/segmenttree/MaxQuerySumUpdateSegmentTreeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/segmenttree/MaxQuerySumUpdateSegmentTreeTest.java
@@ -7,14 +7,14 @@ package com.williamfiset.algorithms.datastructures.segmenttree;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.williamfiset.algorithms.utils.TestUtils;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.api.*;
 
 public class MaxQuerySumUpdateSegmentTreeTest {
 
   static int ITERATIONS = 1000;
 
-  @Before
+  @BeforeEach
   public void setup() {}
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/segmenttree/MaxQuerySumUpdateSegmentTreeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/segmenttree/MaxQuerySumUpdateSegmentTreeTest.java
@@ -7,7 +7,6 @@ package com.williamfiset.algorithms.datastructures.segmenttree;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.williamfiset.algorithms.utils.TestUtils;
-
 import org.junit.jupiter.api.*;
 
 public class MaxQuerySumUpdateSegmentTreeTest {

--- a/src/test/java/com/williamfiset/algorithms/datastructures/segmenttree/MinQueryAssignUpdateSegmentTreeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/segmenttree/MinQueryAssignUpdateSegmentTreeTest.java
@@ -7,14 +7,14 @@ package com.williamfiset.algorithms.datastructures.segmenttree;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.williamfiset.algorithms.utils.TestUtils;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.api.*;
 
 public class MinQueryAssignUpdateSegmentTreeTest {
 
   static int ITERATIONS = 500;
 
-  @Before
+  @BeforeEach
   public void setup() {}
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/segmenttree/MinQueryAssignUpdateSegmentTreeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/segmenttree/MinQueryAssignUpdateSegmentTreeTest.java
@@ -7,7 +7,6 @@ package com.williamfiset.algorithms.datastructures.segmenttree;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.williamfiset.algorithms.utils.TestUtils;
-
 import org.junit.jupiter.api.*;
 
 public class MinQueryAssignUpdateSegmentTreeTest {

--- a/src/test/java/com/williamfiset/algorithms/datastructures/segmenttree/MinQuerySumUpdateSegmentTreeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/segmenttree/MinQuerySumUpdateSegmentTreeTest.java
@@ -7,7 +7,6 @@ package com.williamfiset.algorithms.datastructures.segmenttree;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.williamfiset.algorithms.utils.TestUtils;
-
 import org.junit.jupiter.api.*;
 
 public class MinQuerySumUpdateSegmentTreeTest {

--- a/src/test/java/com/williamfiset/algorithms/datastructures/segmenttree/MinQuerySumUpdateSegmentTreeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/segmenttree/MinQuerySumUpdateSegmentTreeTest.java
@@ -7,14 +7,14 @@ package com.williamfiset.algorithms.datastructures.segmenttree;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.williamfiset.algorithms.utils.TestUtils;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.api.*;
 
 public class MinQuerySumUpdateSegmentTreeTest {
 
   static int ITERATIONS = 1000;
 
-  @Before
+  @BeforeEach
   public void setup() {}
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/segmenttree/SegmentTreeWithPointersTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/segmenttree/SegmentTreeWithPointersTest.java
@@ -6,7 +6,6 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.williamfiset.algorithms.utils.TestUtils;
-
 import org.junit.jupiter.api.*;
 
 public class SegmentTreeWithPointersTest {
@@ -16,17 +15,21 @@ public class SegmentTreeWithPointersTest {
 
   @Test
   public void testIllegalSegmentTreeCreation1() {
-    assertThrows(IllegalArgumentException.class, () -> {
-      Node tree = new Node(null);
-    });
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          Node tree = new Node(null);
+        });
   }
 
   @Test
   public void testIllegalSegmentTreeCreation2() {
-    assertThrows(IllegalArgumentException.class, () -> {
-      int size = -10;
-      Node tree = new Node(size);
-    });
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          int size = -10;
+          Node tree = new Node(size);
+        });
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/segmenttree/SegmentTreeWithPointersTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/segmenttree/SegmentTreeWithPointersTest.java
@@ -3,25 +3,30 @@
 package com.williamfiset.algorithms.datastructures.segmenttree;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.williamfiset.algorithms.utils.TestUtils;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.api.*;
 
 public class SegmentTreeWithPointersTest {
 
-  @Before
+  @BeforeEach
   public void setup() {}
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testIllegalSegmentTreeCreation1() {
-    Node tree = new Node(null);
+    assertThrows(IllegalArgumentException.class, () -> {
+      Node tree = new Node(null);
+    });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testIllegalSegmentTreeCreation2() {
-    int size = -10;
-    Node tree = new Node(size);
+    assertThrows(IllegalArgumentException.class, () -> {
+      int size = -10;
+      Node tree = new Node(size);
+    });
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/segmenttree/SumQueryAssignUpdateSegmentTreeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/segmenttree/SumQueryAssignUpdateSegmentTreeTest.java
@@ -7,7 +7,6 @@ package com.williamfiset.algorithms.datastructures.segmenttree;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.williamfiset.algorithms.utils.TestUtils;
-
 import org.junit.jupiter.api.*;
 
 public class SumQueryAssignUpdateSegmentTreeTest {

--- a/src/test/java/com/williamfiset/algorithms/datastructures/segmenttree/SumQueryAssignUpdateSegmentTreeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/segmenttree/SumQueryAssignUpdateSegmentTreeTest.java
@@ -7,14 +7,14 @@ package com.williamfiset.algorithms.datastructures.segmenttree;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.williamfiset.algorithms.utils.TestUtils;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.api.*;
 
 public class SumQueryAssignUpdateSegmentTreeTest {
 
   static int ITERATIONS = 100;
 
-  @Before
+  @BeforeEach
   public void setup() {}
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/segmenttree/SumQueryMultiplicationUpdateSegmentTreeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/segmenttree/SumQueryMultiplicationUpdateSegmentTreeTest.java
@@ -7,15 +7,14 @@ package com.williamfiset.algorithms.datastructures.segmenttree;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.williamfiset.algorithms.utils.TestUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
 
 public class SumQueryMultiplicationUpdateSegmentTreeTest {
 
   static int ITERATIONS = 100;
   static int MAX_N = 28;
 
-  @Before
+  @BeforeEach
   public void setup() {}
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/segmenttree/SumQuerySumUpdateSegmentTreeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/segmenttree/SumQuerySumUpdateSegmentTreeTest.java
@@ -7,14 +7,14 @@ package com.williamfiset.algorithms.datastructures.segmenttree;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.williamfiset.algorithms.utils.TestUtils;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.api.*;
 
 public class SumQuerySumUpdateSegmentTreeTest {
 
   static int ITERATIONS = 100;
 
-  @Before
+  @BeforeEach
   public void setup() {}
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/segmenttree/SumQuerySumUpdateSegmentTreeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/segmenttree/SumQuerySumUpdateSegmentTreeTest.java
@@ -7,7 +7,6 @@ package com.williamfiset.algorithms.datastructures.segmenttree;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.williamfiset.algorithms.utils.TestUtils;
-
 import org.junit.jupiter.api.*;
 
 public class SumQuerySumUpdateSegmentTreeTest {

--- a/src/test/java/com/williamfiset/algorithms/datastructures/set/HSetTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/set/HSetTest.java
@@ -7,7 +7,8 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
-import org.junit.*;
+
+import org.junit.jupiter.api.*;
 
 // You can set the hash value of this object to be whatever you want
 // This makes it great for testing special cases.
@@ -40,7 +41,7 @@ public class HSetTest {
 
   HSet<Integer> hs;
 
-  @Before
+  @BeforeEach
   public void setup() {
     hs = new HSet<>();
   }

--- a/src/test/java/com/williamfiset/algorithms/datastructures/set/HSetTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/set/HSetTest.java
@@ -7,7 +7,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
-
 import org.junit.jupiter.api.*;
 
 // You can set the hash value of this object to be whatever you want

--- a/src/test/java/com/williamfiset/algorithms/datastructures/skiplist/SkipListTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/skiplist/SkipListTest.java
@@ -8,9 +8,9 @@
  */
 package com.williamfiset.algorithms.datastructures.skiplist;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 public class SkipListTest {
 
@@ -22,11 +22,11 @@ public class SkipListTest {
 
     sl.insert(10);
     sl.insert(25);
-    assertTrue("Index should be 2", sl.getIndex(25) == 2);
+    assertEquals(2, sl.getIndex(25), "Index should be 2");
 
     sl.insert(13);
     sl.insert(14);
-    assertTrue("Index should be 3", sl.getIndex(14) == 3);
+    assertEquals(3, sl.getIndex(14), "Index should be 3");
   }
 
   @Test
@@ -34,7 +34,7 @@ public class SkipListTest {
   public void testIndexWithNonExistingValue() {
     SkipList sl = new SkipList(4, 1, 45);
 
-    assertTrue("Index should be -1", sl.getIndex(44) == -1);
+    assertEquals(-1, sl.getIndex(44), "Index should be -1");
   }
 
   @Test
@@ -43,9 +43,9 @@ public class SkipListTest {
   public void testInsertGreaterThanMaxValue() {
     SkipList sl = new SkipList(3, 1, 65);
 
-    assertTrue("Insert should return false", sl.insert(66) == false);
-    assertTrue("Insert should return false", sl.insert(103) == false);
-    assertTrue("Insert should return false", sl.insert(67) == false);
+    assertFalse(sl.insert(66), "Insert should return false");
+    assertFalse(sl.insert(103), "Insert should return false");
+    assertFalse(sl.insert(67), "Insert should return false");
   }
 
   @Test
@@ -54,10 +54,10 @@ public class SkipListTest {
   public void testInsertLesserThanMinValue() {
     SkipList sl = new SkipList(3, 10, 83);
 
-    assertTrue("Insert should return false", sl.insert(5) == false);
-    assertTrue("Insert should return false", sl.insert(4) == false);
-    assertTrue("Insert should return false", sl.insert(3) == false);
-    assertTrue("Insert should return false", sl.insert(2) == false);
+    assertFalse(sl.insert(5), "Insert should return false");
+    assertFalse(sl.insert(4), "Insert should return false");
+    assertFalse(sl.insert(3), "Insert should return false");
+    assertFalse(sl.insert(2), "Insert should return false");
   }
 
   @Test
@@ -67,14 +67,14 @@ public class SkipListTest {
     sl.insert(5);
     sl.insert(8);
 
-    assertTrue("Size should be 4", sl.size() == 4);
-    assertTrue("Object with key 5 should be found", sl.find(5));
-    assertTrue("Object with key 8 should be found", sl.find(8));
+    assertEquals(4, sl.size(), "Size should be 4");
+    assertTrue(sl.find(5), "Object with key 5 should be found");
+    assertTrue(sl.find(8), "Object with key 8 should be found");
 
     sl.remove(5);
 
-    assertTrue("Size should be 3", sl.size() == 3);
-    assertFalse("Object with key 5 shouldn't be found", sl.find(5));
+    assertEquals(3, sl.size(), "Size should be 3");
+    assertFalse(sl.find(5), "Object with key 5 shouldn't be found");
   }
 
   @Test
@@ -82,19 +82,19 @@ public class SkipListTest {
   public void testSize() {
     SkipList sl = new SkipList(3, 1, 10);
 
-    assertTrue("Size should be initialized to 2", sl.size() == 2);
+    assertEquals(2, sl.size(), "Size should be initialized to 2");
 
     sl.insert(3);
     sl.insert(4);
     sl.insert(5);
 
-    assertTrue("Size should be 5", sl.size() == 5);
-    assertFalse("Size shouldn't be 4", sl.size() == 4);
+    assertEquals(5, sl.size(), "Size should be 5");
+    assertNotEquals(4, sl.size(), "Size shouldn't be 4");
 
     sl.remove(3);
     sl.remove(4);
 
-    assertTrue("Size should be 3", sl.size() == 3);
+    assertEquals(3, sl.size(), "Size should be 3");
   }
 
   @Test
@@ -112,13 +112,13 @@ public class SkipListTest {
     sl.insert(30);
     sl.insert(24);
 
-    assertTrue("Size should be 11", sl.size() == 11);
-    assertTrue("Object with key 43 should be found", sl.find(43));
-    assertFalse("Object with key 44 shouldn't be found", sl.find(44));
+    assertEquals(11, sl.size(), "Size should be 11");
+    assertTrue(sl.find(43), "Object with key 43 should be found");
+    assertFalse(sl.find(44), "Object with key 44 shouldn't be found");
 
     sl.remove(43);
 
-    assertFalse("Object with key 43 shouldn't be found", sl.find(43));
+    assertFalse(sl.find(43), "Object with key 43 shouldn't be found");
   }
 
   @Test
@@ -128,12 +128,12 @@ public class SkipListTest {
     SkipList sl = new SkipList(2, 2, 5);
     sl.insert(4);
 
-    assertFalse("Duplicate insert should return false", sl.insert(4));
-    assertTrue("Duplicate should not exist, size should be 3", sl.size() == 3);
+    assertFalse(sl.insert(4), "Duplicate insert should return false");
+    assertEquals(3, sl.size(), "Duplicate should not exist, size should be 3");
 
     sl.remove(4);
 
-    assertFalse("Element exist after removal", sl.find(4));
+    assertFalse(sl.find(4), "Element exist after removal");
   }
 
   @Test
@@ -141,12 +141,12 @@ public class SkipListTest {
   public void testRemoveNonExisting() {
     SkipList sl = new SkipList(2, 2, 5);
 
-    assertFalse("Remove should return false when Object does not exist", sl.remove(4));
+    assertFalse(sl.remove(4), "Remove should return false when Object does not exist");
 
     sl.insert(4);
 
-    assertTrue("Object should be removable", sl.remove(4));
-    assertFalse("Remove should return false when it has already been removed", sl.remove(4));
+    assertTrue(sl.remove(4), "Object should be removable");
+    assertFalse(sl.remove(4), "Remove should return false when it has already been removed");
   }
 
   @Test
@@ -154,7 +154,7 @@ public class SkipListTest {
   public void testRemoveHeadTail() {
     SkipList sl = new SkipList(3, 1, 10);
 
-    assertFalse("Head shouldn't be removable", sl.remove(1));
-    assertFalse("Tail shouldn't be removable", sl.remove(10));
+    assertFalse(sl.remove(1), "Head shouldn't be removable");
+    assertFalse(sl.remove(10), "Tail shouldn't be removable");
   }
 }

--- a/src/test/java/com/williamfiset/algorithms/datastructures/sparsetable/SparseTableTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/sparsetable/SparseTableTest.java
@@ -3,7 +3,6 @@ package com.williamfiset.algorithms.datastructures.sparsetable;
 import static com.google.common.truth.Truth.assertThat;
 
 import java.util.*;
-
 import org.junit.jupiter.api.*;
 
 public class SparseTableTest {

--- a/src/test/java/com/williamfiset/algorithms/datastructures/sparsetable/SparseTableTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/sparsetable/SparseTableTest.java
@@ -3,7 +3,8 @@ package com.williamfiset.algorithms.datastructures.sparsetable;
 import static com.google.common.truth.Truth.assertThat;
 
 import java.util.*;
-import org.junit.*;
+
+import org.junit.jupiter.api.*;
 
 public class SparseTableTest {
 

--- a/src/test/java/com/williamfiset/algorithms/datastructures/stack/StackTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/stack/StackTest.java
@@ -1,88 +1,82 @@
 package com.williamfiset.algorithms.datastructures.stack;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class StackTest {
 
-  private List<Stack<Integer>> stacks = new ArrayList<>();
-
-  @Before
-  public void setup() {
+  private static List<Stack<Integer>> inputs() {
+    List<Stack<Integer>> stacks = new ArrayList<>();
     stacks.add(new ListStack<Integer>());
     stacks.add(new ArrayStack<Integer>());
     stacks.add(new IntStack(2));
+    return stacks;
   }
 
-  @Test
-  public void testEmptyStack() {
-    for (Stack stack : stacks) {
-      assertThat(stack.isEmpty()).isTrue();
-      assertThat(stack.size()).isEqualTo(0);
-    }
+  @ParameterizedTest
+  @MethodSource("inputs")
+  public void testEmptyStack(Stack<Integer> stack) {
+    assertThat(stack.isEmpty()).isTrue();
+    assertThat(stack.size()).isEqualTo(0);
   }
 
-  @Test(expected = Exception.class)
-  public void testPopOnEmpty() {
-    for (Stack stack : stacks) {
-      stack.pop();
-    }
+  @ParameterizedTest
+  @MethodSource("inputs")
+  public void testPopOnEmpty(Stack<Integer> stack) {
+    assertThrows(Exception.class, () -> stack.pop());
   }
 
-  @Test(expected = Exception.class)
-  public void testPeekOnEmpty() {
-    for (Stack stack : stacks) {
-      stack.peek();
-    }
+  @ParameterizedTest
+  @MethodSource("inputs")
+  public void testPeekOnEmpty(Stack<Integer> stack) {
+    assertThrows(Exception.class, () -> stack.peek());
   }
 
-  @Test
-  public void testPush() {
-    for (Stack<Integer> stack : stacks) {
-      stack.push(2);
-      assertThat(stack.size()).isEqualTo(1);
-    }
+  @ParameterizedTest
+  @MethodSource("inputs")
+  public void testPush(Stack<Integer> stack) {
+    stack.push(2);
+    assertThat(stack.size()).isEqualTo(1);
   }
 
-  @Test
-  public void testPeek() {
-    for (Stack<Integer> stack : stacks) {
-      stack.push(2);
-      assertThat((int) (Integer) stack.peek()).isEqualTo(2);
-      assertThat(stack.size()).isEqualTo(1);
-    }
+  @ParameterizedTest
+  @MethodSource("inputs")
+  public void testPeek(Stack<Integer> stack) {
+    stack.push(2);
+    assertThat((int) (Integer) stack.peek()).isEqualTo(2);
+    assertThat(stack.size()).isEqualTo(1);
   }
 
-  @Test
-  public void testPop() {
-    for (Stack<Integer> stack : stacks) {
-      stack.push(2);
-      assertThat((int) stack.pop()).isEqualTo(2);
-      assertThat(stack.size()).isEqualTo(0);
-    }
+  @ParameterizedTest
+  @MethodSource("inputs")
+  public void testPop(Stack<Integer> stack) {
+    stack.push(2);
+    assertThat((int) stack.pop()).isEqualTo(2);
+    assertThat(stack.size()).isEqualTo(0);
   }
 
-  @Test
-  public void testExhaustively() {
-    for (Stack<Integer> stack : stacks) {
-      assertThat(stack.isEmpty()).isTrue();
-      stack.push(1);
-      assertThat(stack.isEmpty()).isFalse();
-      stack.push(2);
-      assertThat(stack.size()).isEqualTo(2);
-      assertThat((int) stack.peek()).isEqualTo(2);
-      assertThat(stack.size()).isEqualTo(2);
-      assertThat((int) stack.pop()).isEqualTo(2);
-      assertThat(stack.size()).isEqualTo(1);
-      assertThat((int) stack.peek()).isEqualTo(1);
-      assertThat(stack.size()).isEqualTo(1);
-      assertThat((int) stack.pop()).isEqualTo(1);
-      assertThat(stack.size()).isEqualTo(0);
-      assertThat(stack.isEmpty()).isTrue();
-    }
+  @ParameterizedTest
+  @MethodSource("inputs")
+  public void testExhaustively(Stack<Integer> stack) {
+    assertThat(stack.isEmpty()).isTrue();
+    stack.push(1);
+    assertThat(stack.isEmpty()).isFalse();
+    stack.push(2);
+    assertThat(stack.size()).isEqualTo(2);
+    assertThat((int) stack.peek()).isEqualTo(2);
+    assertThat(stack.size()).isEqualTo(2);
+    assertThat((int) stack.pop()).isEqualTo(2);
+    assertThat(stack.size()).isEqualTo(1);
+    assertThat((int) stack.peek()).isEqualTo(1);
+    assertThat(stack.size()).isEqualTo(1);
+    assertThat((int) stack.pop()).isEqualTo(1);
+    assertThat(stack.size()).isEqualTo(0);
+    assertThat(stack.isEmpty()).isTrue();
   }
 }

--- a/src/test/java/com/williamfiset/algorithms/datastructures/stack/StackTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/stack/StackTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
 import java.util.List;
-
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 

--- a/src/test/java/com/williamfiset/algorithms/datastructures/suffixarray/SuffixArrayTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/suffixarray/SuffixArrayTest.java
@@ -4,7 +4,8 @@ import static com.google.common.truth.Truth.assertThat;
 
 import java.security.SecureRandom;
 import java.util.Random;
-import org.junit.*;
+
+import org.junit.jupiter.api.*;
 
 public class SuffixArrayTest {
 
@@ -18,7 +19,7 @@ public class SuffixArrayTest {
 
   String ASCII_LETTERS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
-  @Before
+  @BeforeEach
   public void setup() {}
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/suffixarray/SuffixArrayTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/suffixarray/SuffixArrayTest.java
@@ -4,7 +4,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import java.security.SecureRandom;
 import java.util.Random;
-
 import org.junit.jupiter.api.*;
 
 public class SuffixArrayTest {

--- a/src/test/java/com/williamfiset/algorithms/datastructures/trie/TrieTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/trie/TrieTest.java
@@ -11,50 +11,62 @@ public class TrieTest {
 
   @Test
   public void testBadTrieDelete1() {
-    assertThrows(IllegalArgumentException.class, () -> {
-      Trie t = new Trie();
-      t.insert("some string");
-      t.delete("some string", 0);
-    });
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          Trie t = new Trie();
+          t.insert("some string");
+          t.delete("some string", 0);
+        });
   }
 
   @Test
   public void testBadTrieDelete2() {
-    assertThrows(IllegalArgumentException.class, () -> {
-      Trie t = new Trie();
-      t.insert("some string");
-      t.delete("some string", -1);
-    });
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          Trie t = new Trie();
+          t.insert("some string");
+          t.delete("some string", -1);
+        });
   }
 
   @Test
   public void testBadTrieDelete3() {
-    assertThrows(IllegalArgumentException.class, () -> {
-      Trie t = new Trie();
-      t.insert("some string");
-      t.delete("some string", -345);
-    });
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          Trie t = new Trie();
+          t.insert("some string");
+          t.delete("some string", -345);
+        });
   }
 
   @Test
   public void testBadTrieInsert() {
-    assertThrows(IllegalArgumentException.class, () -> {
-      (new Trie()).insert(null);
-    });
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          (new Trie()).insert(null);
+        });
   }
 
   @Test
   public void testBadTrieCount() {
-    assertThrows(IllegalArgumentException.class, () -> {
-      (new Trie()).count(null);
-    });
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          (new Trie()).count(null);
+        });
   }
 
   @Test
   public void testBadTrieContains() {
-    assertThrows(IllegalArgumentException.class, () -> {
-      (new Trie()).contains(null);
-    });
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          (new Trie()).contains(null);
+        });
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/trie/TrieTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/trie/TrieTest.java
@@ -1,47 +1,60 @@
 package com.williamfiset.algorithms.datastructures.trie;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 public class TrieTest {
 
-  // @Before public void setup() { }
+  // @BeforeEach public void setup() { }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testBadTrieDelete1() {
-    Trie t = new Trie();
-    t.insert("some string");
-    t.delete("some string", 0);
+    assertThrows(IllegalArgumentException.class, () -> {
+      Trie t = new Trie();
+      t.insert("some string");
+      t.delete("some string", 0);
+    });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testBadTrieDelete2() {
-    Trie t = new Trie();
-    t.insert("some string");
-    t.delete("some string", -1);
+    assertThrows(IllegalArgumentException.class, () -> {
+      Trie t = new Trie();
+      t.insert("some string");
+      t.delete("some string", -1);
+    });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testBadTrieDelete3() {
-    Trie t = new Trie();
-    t.insert("some string");
-    t.delete("some string", -345);
+    assertThrows(IllegalArgumentException.class, () -> {
+      Trie t = new Trie();
+      t.insert("some string");
+      t.delete("some string", -345);
+    });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testBadTrieInsert() {
-    (new Trie()).insert(null);
+    assertThrows(IllegalArgumentException.class, () -> {
+      (new Trie()).insert(null);
+    });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testBadTrieCount() {
-    (new Trie()).count(null);
+    assertThrows(IllegalArgumentException.class, () -> {
+      (new Trie()).count(null);
+    });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testBadTrieContains() {
-    (new Trie()).contains(null);
+    assertThrows(IllegalArgumentException.class, () -> {
+      (new Trie()).contains(null);
+    });
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/unionfind/UnionFindTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/unionfind/UnionFindTest.java
@@ -2,8 +2,11 @@ package com.williamfiset.algorithms.datastructures.unionfind;
 
 // import static org.junit.Assert.*;
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class UnionFindTest {
 
@@ -218,18 +221,9 @@ public class UnionFindTest {
     assertThat(uf.size()).isEqualTo(5);
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testBadUnionFindCreation1() {
-    new UnionFind(-1);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testBadUnionFindCreation2() {
-    new UnionFind(-3463);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testBadUnionFindCreation3() {
-    new UnionFind(0);
+  @ParameterizedTest(name = "Size: {0}")
+  @ValueSource(ints = {-1, -3463, 0})
+  public void testBadUnionFindCreation(int size) {
+    assertThrows(IllegalArgumentException.class, () -> new UnionFind(size));
   }
 }

--- a/src/test/java/com/williamfiset/algorithms/dp/CoinChangeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/dp/CoinChangeTest.java
@@ -2,10 +2,11 @@ package com.williamfiset.algorithms.dp;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import java.util.*;
+
 import com.google.common.primitives.Ints;
 import com.williamfiset.algorithms.utils.TestUtils;
-import java.util.*;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 public class CoinChangeTest {
 

--- a/src/test/java/com/williamfiset/algorithms/dp/CoinChangeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/dp/CoinChangeTest.java
@@ -2,10 +2,9 @@ package com.williamfiset.algorithms.dp;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import java.util.*;
-
 import com.google.common.primitives.Ints;
 import com.williamfiset.algorithms.utils.TestUtils;
+import java.util.*;
 import org.junit.jupiter.api.*;
 
 public class CoinChangeTest {

--- a/src/test/java/com/williamfiset/algorithms/dp/WeightedMaximumCardinalityMatchingTest.java
+++ b/src/test/java/com/williamfiset/algorithms/dp/WeightedMaximumCardinalityMatchingTest.java
@@ -3,7 +3,8 @@ package com.williamfiset.algorithms.dp;
 import static com.google.common.truth.Truth.assertThat;
 
 import java.util.*;
-import org.junit.*;
+
+import org.junit.jupiter.api.*;
 
 public class WeightedMaximumCardinalityMatchingTest {
 

--- a/src/test/java/com/williamfiset/algorithms/dp/WeightedMaximumCardinalityMatchingTest.java
+++ b/src/test/java/com/williamfiset/algorithms/dp/WeightedMaximumCardinalityMatchingTest.java
@@ -3,7 +3,6 @@ package com.williamfiset.algorithms.dp;
 import static com.google.common.truth.Truth.assertThat;
 
 import java.util.*;
-
 import org.junit.jupiter.api.*;
 
 public class WeightedMaximumCardinalityMatchingTest {
@@ -399,7 +398,7 @@ public class WeightedMaximumCardinalityMatchingTest {
     for (int loop = 0; loop < LOOPS; loop++) {
       int n = Math.max(1, (int) (Math.random() * 6)) * 2; // n is either 2,4,6,8, or 10
       Double[][] costMatrix = new Double[n][n];
-      randomFillSymmetricMatrix(costMatrix, /*maxValue=*/ 10000);
+      randomFillSymmetricMatrix(costMatrix, /* maxValue= */ 10000);
 
       MwpmInterface[] impls = getImplementations(costMatrix);
       for (MwpmInterface mwpm : impls) {
@@ -417,7 +416,7 @@ public class WeightedMaximumCardinalityMatchingTest {
     for (int loop = 0; loop < LOOPS; loop++) {
       int n = Math.max(1, (int) (Math.random() * 6)) * 2; // n is either 2,4,6,8, or 10
       Double[][] costMatrix = new Double[n][n];
-      randomFillSymmetricMatrix(costMatrix, /*maxValue=*/ 3);
+      randomFillSymmetricMatrix(costMatrix, /* maxValue= */ 3);
 
       MwpmInterface[] impls = getImplementations(costMatrix);
       for (MwpmInterface mwpm : impls) {

--- a/src/test/java/com/williamfiset/algorithms/geometry/ConvexHullMonotoneChainsAlgorithmTest.java
+++ b/src/test/java/com/williamfiset/algorithms/geometry/ConvexHullMonotoneChainsAlgorithmTest.java
@@ -4,7 +4,8 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import java.awt.geom.*;
-import org.junit.*;
+
+import org.junit.jupiter.api.*;
 
 public class ConvexHullMonotoneChainsAlgorithmTest {
 

--- a/src/test/java/com/williamfiset/algorithms/geometry/ConvexHullMonotoneChainsAlgorithmTest.java
+++ b/src/test/java/com/williamfiset/algorithms/geometry/ConvexHullMonotoneChainsAlgorithmTest.java
@@ -4,7 +4,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import java.awt.geom.*;
-
 import org.junit.jupiter.api.*;
 
 public class ConvexHullMonotoneChainsAlgorithmTest {

--- a/src/test/java/com/williamfiset/algorithms/geometry/MinimumCostConvexPolygonTriangulationTest.java
+++ b/src/test/java/com/williamfiset/algorithms/geometry/MinimumCostConvexPolygonTriangulationTest.java
@@ -3,7 +3,6 @@ package com.williamfiset.algorithms.geometry;
 import static com.google.common.truth.Truth.assertThat;
 
 import java.awt.geom.*;
-
 import org.junit.jupiter.api.*;
 
 public class MinimumCostConvexPolygonTriangulationTest {

--- a/src/test/java/com/williamfiset/algorithms/geometry/MinimumCostConvexPolygonTriangulationTest.java
+++ b/src/test/java/com/williamfiset/algorithms/geometry/MinimumCostConvexPolygonTriangulationTest.java
@@ -3,7 +3,8 @@ package com.williamfiset.algorithms.geometry;
 import static com.google.common.truth.Truth.assertThat;
 
 import java.awt.geom.*;
-import org.junit.*;
+
+import org.junit.jupiter.api.*;
 
 public class MinimumCostConvexPolygonTriangulationTest {
 

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/ArticulationPointsAdjacencyListTest.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/ArticulationPointsAdjacencyListTest.java
@@ -3,7 +3,8 @@ package com.williamfiset.algorithms.graphtheory;
 import static com.google.common.truth.Truth.assertThat;
 
 import java.util.*;
-import org.junit.*;
+
+import org.junit.jupiter.api.*;
 
 public class ArticulationPointsAdjacencyListTest {
 

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/ArticulationPointsAdjacencyListTest.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/ArticulationPointsAdjacencyListTest.java
@@ -3,7 +3,6 @@ package com.williamfiset.algorithms.graphtheory;
 import static com.google.common.truth.Truth.assertThat;
 
 import java.util.*;
-
 import org.junit.jupiter.api.*;
 
 public class ArticulationPointsAdjacencyListTest {

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/BreadthFirstSearchAdjacencyListIterativeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/BreadthFirstSearchAdjacencyListIterativeTest.java
@@ -6,25 +6,26 @@ import static com.williamfiset.algorithms.graphtheory.BreadthFirstSearchAdjacenc
 import static com.williamfiset.algorithms.graphtheory.BreadthFirstSearchAdjacencyListIterative.createEmptyGraph;
 import static java.lang.Math.max;
 import static java.lang.Math.random;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.api.*;
 
 public class BreadthFirstSearchAdjacencyListIterativeTest {
 
   BreadthFirstSearchAdjacencyListIterative solver;
 
-  @Before
+  @BeforeEach
   public void setup() {
     solver = null;
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testNullGraphInput() {
-    new BreadthFirstSearchAdjacencyListIterative(null);
+    assertThrows(IllegalArgumentException.class, () -> new BreadthFirstSearchAdjacencyListIterative(null));
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/BreadthFirstSearchAdjacencyListIterativeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/BreadthFirstSearchAdjacencyListIterativeTest.java
@@ -11,7 +11,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
 import org.junit.jupiter.api.*;
 
 public class BreadthFirstSearchAdjacencyListIterativeTest {
@@ -25,7 +24,8 @@ public class BreadthFirstSearchAdjacencyListIterativeTest {
 
   @Test
   public void testNullGraphInput() {
-    assertThrows(IllegalArgumentException.class, () -> new BreadthFirstSearchAdjacencyListIterative(null));
+    assertThrows(
+        IllegalArgumentException.class, () -> new BreadthFirstSearchAdjacencyListIterative(null));
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/BridgesAdjacencyListIterativeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/BridgesAdjacencyListIterativeTest.java
@@ -2,10 +2,11 @@ package com.williamfiset.algorithms.graphtheory;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.google.common.collect.ImmutableList;
 import java.util.*;
+
+import com.google.common.collect.ImmutableList;
 import org.apache.commons.lang3.tuple.Pair;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 public class BridgesAdjacencyListIterativeTest {
 

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/BridgesAdjacencyListIterativeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/BridgesAdjacencyListIterativeTest.java
@@ -2,9 +2,8 @@ package com.williamfiset.algorithms.graphtheory;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import java.util.*;
-
 import com.google.common.collect.ImmutableList;
+import java.util.*;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.*;
 

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/BridgesAdjacencyListTest.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/BridgesAdjacencyListTest.java
@@ -2,9 +2,8 @@ package com.williamfiset.algorithms.graphtheory;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import java.util.*;
-
 import com.google.common.collect.ImmutableList;
+import java.util.*;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.*;
 

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/BridgesAdjacencyListTest.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/BridgesAdjacencyListTest.java
@@ -2,10 +2,11 @@ package com.williamfiset.algorithms.graphtheory;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.google.common.collect.ImmutableList;
 import java.util.*;
+
+import com.google.common.collect.ImmutableList;
 import org.apache.commons.lang3.tuple.Pair;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 public class BridgesAdjacencyListTest {
 

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/EulerianPathDirectedEdgesAdjacencyListTest.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/EulerianPathDirectedEdgesAdjacencyListTest.java
@@ -3,13 +3,14 @@ package com.williamfiset.algorithms.graphtheory;
 import static com.google.common.truth.Truth.assertThat;
 
 import java.util.*;
-import org.junit.*;
+
+import org.junit.jupiter.api.*;
 
 public class EulerianPathDirectedEdgesAdjacencyListTest {
 
   EulerianPathDirectedEdgesAdjacencyList solver;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     solver = null;
   }

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/EulerianPathDirectedEdgesAdjacencyListTest.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/EulerianPathDirectedEdgesAdjacencyListTest.java
@@ -3,7 +3,6 @@ package com.williamfiset.algorithms.graphtheory;
 import static com.google.common.truth.Truth.assertThat;
 
 import java.util.*;
-
 import org.junit.jupiter.api.*;
 
 public class EulerianPathDirectedEdgesAdjacencyListTest {

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/FloydWarshallSolverTest.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/FloydWarshallSolverTest.java
@@ -3,8 +3,8 @@ package com.williamfiset.algorithms.graphtheory;
 import static com.google.common.truth.Truth.assertThat;
 
 import java.util.*;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.api.*;
 
 public class FloydWarshallSolverTest {
 
@@ -13,7 +13,7 @@ public class FloydWarshallSolverTest {
 
   static double[][] matrix1, matrix2, matrix3;
 
-  @Before
+  @BeforeEach
   public void setup() {
     matrix1 =
         new double[][] {

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/FloydWarshallSolverTest.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/FloydWarshallSolverTest.java
@@ -3,7 +3,6 @@ package com.williamfiset.algorithms.graphtheory;
 import static com.google.common.truth.Truth.assertThat;
 
 import java.util.*;
-
 import org.junit.jupiter.api.*;
 
 public class FloydWarshallSolverTest {

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/KahnsTest.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/KahnsTest.java
@@ -3,10 +3,9 @@ package com.williamfiset.algorithms.graphtheory;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.util.*;
-
 import com.williamfiset.algorithms.utils.graphutils.GraphGenerator;
 import com.williamfiset.algorithms.utils.graphutils.Utils;
+import java.util.*;
 import org.junit.jupiter.api.*;
 
 public class KahnsTest {

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/KahnsTest.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/KahnsTest.java
@@ -1,11 +1,13 @@
 package com.williamfiset.algorithms.graphtheory;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.*;
 
 import com.williamfiset.algorithms.utils.graphutils.GraphGenerator;
 import com.williamfiset.algorithms.utils.graphutils.Utils;
-import java.util.*;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 public class KahnsTest {
 
@@ -40,7 +42,7 @@ public class KahnsTest {
     return true;
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void cycleInGraph() {
     List<List<Integer>> g = Utils.createEmptyAdjacencyList(4);
     Utils.addDirectedEdge(g, 0, 1);
@@ -48,7 +50,7 @@ public class KahnsTest {
     Utils.addDirectedEdge(g, 2, 3);
     Utils.addDirectedEdge(g, 3, 0);
     Kahns solver = new Kahns();
-    solver.kahns(g);
+    assertThrows(IllegalArgumentException.class, () -> solver.kahns(g));
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/KosarajuTest.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/KosarajuTest.java
@@ -8,9 +8,8 @@ package com.williamfiset.algorithms.graphtheory;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
-import java.util.*;
-
 import com.google.common.collect.ImmutableList;
+import java.util.*;
 import org.junit.jupiter.api.*;
 
 public class KosarajuTest {

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/KosarajuTest.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/KosarajuTest.java
@@ -6,10 +6,12 @@
 package com.williamfiset.algorithms.graphtheory;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+
+import java.util.*;
 
 import com.google.common.collect.ImmutableList;
-import java.util.*;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 public class KosarajuTest {
 
@@ -25,9 +27,9 @@ public class KosarajuTest {
     graph.get(from).add(to);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void nullGraphConstructor() {
-    new Kosaraju(null);
+    assertThrowsExactly(IllegalArgumentException.class, () -> new Kosaraju(null));
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/SteinerTreeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/SteinerTreeTest.java
@@ -2,7 +2,7 @@ package com.williamfiset.algorithms.graphtheory;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 public class SteinerTreeTest {
 

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/TarjanSccSolverAdjacencyListTest.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/TarjanSccSolverAdjacencyListTest.java
@@ -1,10 +1,12 @@
 package com.williamfiset.algorithms.graphtheory;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.*;
 
 import com.google.common.collect.ImmutableList;
-import java.util.*;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 public class TarjanSccSolverAdjacencyListTest {
 
@@ -20,9 +22,9 @@ public class TarjanSccSolverAdjacencyListTest {
     graph.get(from).add(to);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void nullGraphConstructor() {
-    new TarjanSccSolverAdjacencyList(null);
+    assertThrows(IllegalArgumentException.class, () -> new TarjanSccSolverAdjacencyList(null));
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/TarjanSccSolverAdjacencyListTest.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/TarjanSccSolverAdjacencyListTest.java
@@ -3,9 +3,8 @@ package com.williamfiset.algorithms.graphtheory;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.util.*;
-
 import com.google.common.collect.ImmutableList;
+import java.util.*;
 import org.junit.jupiter.api.*;
 
 public class TarjanSccSolverAdjacencyListTest {

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/TravelingSalesmanProblemTest.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/TravelingSalesmanProblemTest.java
@@ -4,7 +4,6 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.*;
-
 import org.junit.jupiter.api.*;
 
 public class TravelingSalesmanProblemTest {
@@ -18,7 +17,8 @@ public class TravelingSalesmanProblemTest {
       {4, 5, 6},
       {7, 8, 9}
     };
-    assertThrows(IllegalArgumentException.class, () -> new TspDynamicProgrammingRecursive(321, dist));
+    assertThrows(
+        IllegalArgumentException.class, () -> new TspDynamicProgrammingRecursive(321, dist));
   }
 
   @Test
@@ -28,7 +28,8 @@ public class TravelingSalesmanProblemTest {
       {4, 5, 6},
       {7, 8, 9}
     };
-    assertThrows(IllegalArgumentException.class, () -> new TspDynamicProgrammingIterative(321, dist));
+    assertThrows(
+        IllegalArgumentException.class, () -> new TspDynamicProgrammingIterative(321, dist));
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/TravelingSalesmanProblemTest.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/TravelingSalesmanProblemTest.java
@@ -1,68 +1,70 @@
 package com.williamfiset.algorithms.graphtheory;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.*;
-import org.junit.*;
+
+import org.junit.jupiter.api.*;
 
 public class TravelingSalesmanProblemTest {
 
   private static final double EPS = 1e-5;
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testTspRecursiveInvalidStartNode() {
     double[][] dist = {
       {1, 2, 3},
       {4, 5, 6},
       {7, 8, 9}
     };
-    new TspDynamicProgrammingRecursive(321, dist);
+    assertThrows(IllegalArgumentException.class, () -> new TspDynamicProgrammingRecursive(321, dist));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testTspIterativeInvalidStartNode() {
     double[][] dist = {
       {1, 2, 3},
       {4, 5, 6},
       {7, 8, 9}
     };
-    new TspDynamicProgrammingIterative(321, dist);
+    assertThrows(IllegalArgumentException.class, () -> new TspDynamicProgrammingIterative(321, dist));
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testTspRecursiveNonSquareMatrix() {
     double[][] dist = {
       {1, 2, 3},
       {4, 5, 6}
     };
-    new TspDynamicProgrammingRecursive(dist);
+    assertThrows(IllegalStateException.class, () -> new TspDynamicProgrammingRecursive(dist));
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testTspIterativeNonSquareMatrix() {
     double[][] dist = {
       {1, 2, 3},
       {4, 5, 6}
     };
-    new TspDynamicProgrammingIterative(dist);
+    assertThrows(IllegalStateException.class, () -> new TspDynamicProgrammingIterative(dist));
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testTspRecursiveSmallGraph() {
     double[][] dist = {
       {0, 1},
       {1, 0}
     };
-    new TspDynamicProgrammingRecursive(dist);
+    assertThrows(IllegalStateException.class, () -> new TspDynamicProgrammingRecursive(dist));
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testTspIterativeSmallGraph() {
     double[][] dist = {
       {0, 1},
       {1, 0}
     };
-    new TspDynamicProgrammingIterative(dist);
+    assertThrows(IllegalStateException.class, () -> new TspDynamicProgrammingIterative(dist));
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/TwoSatSolverAdjacencyListTest.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/TwoSatSolverAdjacencyListTest.java
@@ -3,7 +3,6 @@ package com.williamfiset.algorithms.graphtheory;
 import static com.google.common.truth.Truth.assertThat;
 
 import java.util.*;
-
 import org.junit.jupiter.api.*;
 
 public class TwoSatSolverAdjacencyListTest {

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/TwoSatSolverAdjacencyListTest.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/TwoSatSolverAdjacencyListTest.java
@@ -3,7 +3,8 @@ package com.williamfiset.algorithms.graphtheory;
 import static com.google.common.truth.Truth.assertThat;
 
 import java.util.*;
-import org.junit.*;
+
+import org.junit.jupiter.api.*;
 
 public class TwoSatSolverAdjacencyListTest {
 

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/networkflow/BipartiteGraphCheckAdjacencyListTest.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/networkflow/BipartiteGraphCheckAdjacencyListTest.java
@@ -2,16 +2,17 @@ package com.williamfiset.algorithms.graphtheory.networkflow;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.williamfiset.algorithms.utils.graphutils.Utils;
 import java.util.*;
-import org.junit.*;
+
+import com.williamfiset.algorithms.utils.graphutils.Utils;
+import org.junit.jupiter.api.*;
 
 public class BipartiteGraphCheckAdjacencyListTest {
 
   private List<List<Integer>> graph;
   private BipartiteGraphCheckAdjacencyList solver;
 
-  @Before
+  @BeforeEach
   public void setUp() {}
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/networkflow/BipartiteGraphCheckAdjacencyListTest.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/networkflow/BipartiteGraphCheckAdjacencyListTest.java
@@ -2,9 +2,8 @@ package com.williamfiset.algorithms.graphtheory.networkflow;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import java.util.*;
-
 import com.williamfiset.algorithms.utils.graphutils.Utils;
+import java.util.*;
 import org.junit.jupiter.api.*;
 
 public class BipartiteGraphCheckAdjacencyListTest {

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/networkflow/MaxFlowTests.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/networkflow/MaxFlowTests.java
@@ -2,9 +2,8 @@ package com.williamfiset.algorithms.graphtheory.networkflow;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import java.util.*;
-
 import com.williamfiset.algorithms.graphtheory.networkflow.NetworkFlowSolverBase.Edge;
+import java.util.*;
 import org.junit.jupiter.api.*;
 
 public class MaxFlowTests {

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/networkflow/MaxFlowTests.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/networkflow/MaxFlowTests.java
@@ -2,15 +2,16 @@ package com.williamfiset.algorithms.graphtheory.networkflow;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.williamfiset.algorithms.graphtheory.networkflow.NetworkFlowSolverBase.Edge;
 import java.util.*;
-import org.junit.*;
+
+import com.williamfiset.algorithms.graphtheory.networkflow.NetworkFlowSolverBase.Edge;
+import org.junit.jupiter.api.*;
 
 public class MaxFlowTests {
 
   List<NetworkFlowSolverBase> solvers;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     solvers = new ArrayList<>();
   }

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/networkflow/MinCostMaxFlowTests.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/networkflow/MinCostMaxFlowTests.java
@@ -3,7 +3,6 @@ package com.williamfiset.algorithms.graphtheory.networkflow;
 import static com.google.common.truth.Truth.assertThat;
 
 import java.util.*;
-
 import org.junit.jupiter.api.*;
 
 public class MinCostMaxFlowTests {

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/networkflow/MinCostMaxFlowTests.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/networkflow/MinCostMaxFlowTests.java
@@ -3,13 +3,14 @@ package com.williamfiset.algorithms.graphtheory.networkflow;
 import static com.google.common.truth.Truth.assertThat;
 
 import java.util.*;
-import org.junit.*;
+
+import org.junit.jupiter.api.*;
 
 public class MinCostMaxFlowTests {
 
   List<NetworkFlowSolverBase> solvers;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     solvers = new ArrayList<>();
   }

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/treealgorithms/LowestCommonAncestorEulerTourTest.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/treealgorithms/LowestCommonAncestorEulerTourTest.java
@@ -3,7 +3,8 @@ package com.williamfiset.algorithms.graphtheory.treealgorithms;
 import static com.google.common.truth.Truth.assertThat;
 
 import java.util.*;
-import org.junit.*;
+
+import org.junit.jupiter.api.*;
 
 public class LowestCommonAncestorEulerTourTest {
 

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/treealgorithms/LowestCommonAncestorEulerTourTest.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/treealgorithms/LowestCommonAncestorEulerTourTest.java
@@ -3,7 +3,6 @@ package com.williamfiset.algorithms.graphtheory.treealgorithms;
 import static com.google.common.truth.Truth.assertThat;
 
 import java.util.*;
-
 import org.junit.jupiter.api.*;
 
 public class LowestCommonAncestorEulerTourTest {

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/treealgorithms/LowestCommonAncestorTest.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/treealgorithms/LowestCommonAncestorTest.java
@@ -4,9 +4,8 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.williamfiset.algorithms.graphtheory.treealgorithms.LowestCommonAncestor.addUndirectedEdge;
 import static com.williamfiset.algorithms.graphtheory.treealgorithms.LowestCommonAncestor.createEmptyGraph;
 
-import java.util.*;
-
 import com.williamfiset.algorithms.graphtheory.treealgorithms.LowestCommonAncestor.TreeNode;
+import java.util.*;
 import org.junit.jupiter.api.*;
 
 public class LowestCommonAncestorTest {

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/treealgorithms/LowestCommonAncestorTest.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/treealgorithms/LowestCommonAncestorTest.java
@@ -4,9 +4,10 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.williamfiset.algorithms.graphtheory.treealgorithms.LowestCommonAncestor.addUndirectedEdge;
 import static com.williamfiset.algorithms.graphtheory.treealgorithms.LowestCommonAncestor.createEmptyGraph;
 
-import com.williamfiset.algorithms.graphtheory.treealgorithms.LowestCommonAncestor.TreeNode;
 import java.util.*;
-import org.junit.*;
+
+import com.williamfiset.algorithms.graphtheory.treealgorithms.LowestCommonAncestor.TreeNode;
+import org.junit.jupiter.api.*;
 
 public class LowestCommonAncestorTest {
 

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/treealgorithms/RootingTreeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/treealgorithms/RootingTreeTest.java
@@ -2,9 +2,8 @@ package com.williamfiset.algorithms.graphtheory.treealgorithms;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import java.util.*;
-
 import com.williamfiset.algorithms.graphtheory.treealgorithms.RootingTree.TreeNode;
+import java.util.*;
 import org.junit.jupiter.api.*;
 
 public class RootingTreeTest {

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/treealgorithms/RootingTreeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/treealgorithms/RootingTreeTest.java
@@ -2,9 +2,10 @@ package com.williamfiset.algorithms.graphtheory.treealgorithms;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.williamfiset.algorithms.graphtheory.treealgorithms.RootingTree.TreeNode;
 import java.util.*;
-import org.junit.*;
+
+import com.williamfiset.algorithms.graphtheory.treealgorithms.RootingTree.TreeNode;
+import org.junit.jupiter.api.*;
 
 public class RootingTreeTest {
 

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/treealgorithms/TreeCenterLongestPathImplTest.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/treealgorithms/TreeCenterLongestPathImplTest.java
@@ -11,7 +11,6 @@ import static com.williamfiset.algorithms.graphtheory.treealgorithms.TreeCenterL
 import static com.williamfiset.algorithms.graphtheory.treealgorithms.TreeCenterLongestPathImpl.findTreeCenters;
 
 import java.util.*;
-
 import org.junit.jupiter.api.*;
 
 public class TreeCenterLongestPathImplTest {

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/treealgorithms/TreeCenterLongestPathImplTest.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/treealgorithms/TreeCenterLongestPathImplTest.java
@@ -11,7 +11,8 @@ import static com.williamfiset.algorithms.graphtheory.treealgorithms.TreeCenterL
 import static com.williamfiset.algorithms.graphtheory.treealgorithms.TreeCenterLongestPathImpl.findTreeCenters;
 
 import java.util.*;
-import org.junit.*;
+
+import org.junit.jupiter.api.*;
 
 public class TreeCenterLongestPathImplTest {
 

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/treealgorithms/TreeCenterTest.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/treealgorithms/TreeCenterTest.java
@@ -11,7 +11,6 @@ import static com.williamfiset.algorithms.graphtheory.treealgorithms.TreeCenter.
 import static com.williamfiset.algorithms.graphtheory.treealgorithms.TreeCenter.findTreeCenters;
 
 import java.util.*;
-
 import org.junit.jupiter.api.*;
 
 public class TreeCenterTest {

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/treealgorithms/TreeCenterTest.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/treealgorithms/TreeCenterTest.java
@@ -11,7 +11,8 @@ import static com.williamfiset.algorithms.graphtheory.treealgorithms.TreeCenter.
 import static com.williamfiset.algorithms.graphtheory.treealgorithms.TreeCenter.findTreeCenters;
 
 import java.util.*;
-import org.junit.*;
+
+import org.junit.jupiter.api.*;
 
 public class TreeCenterTest {
 

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/treealgorithms/TreeIsomorphismTest.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/treealgorithms/TreeIsomorphismTest.java
@@ -12,14 +12,15 @@ import static com.williamfiset.algorithms.graphtheory.treealgorithms.TreeIsomorp
 import static org.junit.Assert.assertThrows;
 
 import java.util.*;
-
 import org.junit.jupiter.api.*;
 
 public class TreeIsomorphismTest {
 
   @Test
   public void emptyTreeThrowsException() {
-    assertThrows(IllegalArgumentException.class, () -> treesAreIsomorphic(createEmptyGraph(0), createEmptyGraph(1)));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> treesAreIsomorphic(createEmptyGraph(0), createEmptyGraph(1)));
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/treealgorithms/TreeIsomorphismTest.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/treealgorithms/TreeIsomorphismTest.java
@@ -9,15 +9,17 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.williamfiset.algorithms.graphtheory.treealgorithms.TreeIsomorphism.addUndirectedEdge;
 import static com.williamfiset.algorithms.graphtheory.treealgorithms.TreeIsomorphism.createEmptyGraph;
 import static com.williamfiset.algorithms.graphtheory.treealgorithms.TreeIsomorphism.treesAreIsomorphic;
+import static org.junit.Assert.assertThrows;
 
 import java.util.*;
-import org.junit.*;
+
+import org.junit.jupiter.api.*;
 
 public class TreeIsomorphismTest {
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void emptyTreeThrowsException() {
-    treesAreIsomorphic(createEmptyGraph(0), createEmptyGraph(1));
+    assertThrows(IllegalArgumentException.class, () -> treesAreIsomorphic(createEmptyGraph(0), createEmptyGraph(1)));
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/treealgorithms/TreeIsomorphismWithBfsTest.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/treealgorithms/TreeIsomorphismWithBfsTest.java
@@ -13,7 +13,8 @@ import static com.williamfiset.algorithms.graphtheory.treealgorithms.TreeIsomorp
 import static com.williamfiset.algorithms.graphtheory.treealgorithms.TreeIsomorphismWithBfs.treesAreIsomorphic;
 
 import java.util.*;
-import org.junit.*;
+
+import org.junit.jupiter.api.*;
 
 public class TreeIsomorphismWithBfsTest {
 

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/treealgorithms/TreeIsomorphismWithBfsTest.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/treealgorithms/TreeIsomorphismWithBfsTest.java
@@ -13,7 +13,6 @@ import static com.williamfiset.algorithms.graphtheory.treealgorithms.TreeIsomorp
 import static com.williamfiset.algorithms.graphtheory.treealgorithms.TreeIsomorphismWithBfs.treesAreIsomorphic;
 
 import java.util.*;
-
 import org.junit.jupiter.api.*;
 
 public class TreeIsomorphismWithBfsTest {

--- a/src/test/java/com/williamfiset/algorithms/other/BitManipulationsTest.java
+++ b/src/test/java/com/williamfiset/algorithms/other/BitManipulationsTest.java
@@ -2,7 +2,7 @@ package com.williamfiset.algorithms.other;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 public class BitManipulationsTest {
 

--- a/src/test/java/com/williamfiset/algorithms/other/LazyRangeAdderTest.java
+++ b/src/test/java/com/williamfiset/algorithms/other/LazyRangeAdderTest.java
@@ -2,7 +2,7 @@ package com.williamfiset.algorithms.other;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LazyRangeAdderTest {
 

--- a/src/test/java/com/williamfiset/algorithms/other/SlidingWindowMaximumTest.java
+++ b/src/test/java/com/williamfiset/algorithms/other/SlidingWindowMaximumTest.java
@@ -2,7 +2,7 @@ package com.williamfiset.algorithms.other;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 public class SlidingWindowMaximumTest {
 

--- a/src/test/java/com/williamfiset/algorithms/search/InterpolationSearchTest.java
+++ b/src/test/java/com/williamfiset/algorithms/search/InterpolationSearchTest.java
@@ -9,10 +9,7 @@ public class InterpolationSearchTest {
 
   private static Arguments[] inputs() {
     return new Arguments[] {
-      Arguments.of(2, 2),
-      Arguments.of(5, 5),
-      Arguments.of(-1, -1),
-      Arguments.of(8, -1)
+      Arguments.of(2, 2), Arguments.of(5, 5), Arguments.of(-1, -1), Arguments.of(8, -1)
     };
   }
 

--- a/src/test/java/com/williamfiset/algorithms/search/InterpolationSearchTest.java
+++ b/src/test/java/com/williamfiset/algorithms/search/InterpolationSearchTest.java
@@ -2,35 +2,25 @@ package com.williamfiset.algorithms.search;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.*;
 
 public class InterpolationSearchTest {
 
-  @Test
-  public void testCoverage1() {
-    int[] arr = {0, 1, 2, 3, 4, 5};
-    int index = InterpolationSearch.interpolationSearch(arr, 2);
-    assertThat(index).isEqualTo(2);
+  private static Arguments[] inputs() {
+    return new Arguments[] {
+      Arguments.of(2, 2),
+      Arguments.of(5, 5),
+      Arguments.of(-1, -1),
+      Arguments.of(8, -1)
+    };
   }
 
-  @Test
-  public void testCoverage2() {
+  @ParameterizedTest(name = "Search value: {0}, Expected index: {1}")
+  @MethodSource("inputs")
+  public void testCoverage(int val, int expected) {
     int[] arr = {0, 1, 2, 3, 4, 5};
-    int index = InterpolationSearch.interpolationSearch(arr, 5);
-    assertThat(index).isEqualTo(5);
-  }
-
-  @Test
-  public void testCoverage3() {
-    int[] arr = {0, 1, 2, 3, 4, 5};
-    int index = InterpolationSearch.interpolationSearch(arr, -1);
-    assertThat(index).isEqualTo(-1);
-  }
-
-  @Test
-  public void testCoverage4() {
-    int[] arr = {0, 1, 2, 3, 4, 5};
-    int index = InterpolationSearch.interpolationSearch(arr, 8);
-    assertThat(index).isEqualTo(-1);
+    int index = InterpolationSearch.interpolationSearch(arr, val);
+    assertThat(index).isEqualTo(expected);
   }
 }

--- a/src/test/java/com/williamfiset/algorithms/sorting/QuickSelectTest.java
+++ b/src/test/java/com/williamfiset/algorithms/sorting/QuickSelectTest.java
@@ -4,7 +4,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.williamfiset.algorithms.utils.TestUtils;
 import java.util.Arrays;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class QuickSelectTest {
 

--- a/src/test/java/com/williamfiset/algorithms/sorting/RadixSortTest.java
+++ b/src/test/java/com/williamfiset/algorithms/sorting/RadixSortTest.java
@@ -4,7 +4,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import java.util.Arrays;
 import java.util.Random;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RadixSortTest {
   static Random random = new Random();

--- a/src/test/java/com/williamfiset/algorithms/sorting/SortingTest.java
+++ b/src/test/java/com/williamfiset/algorithms/sorting/SortingTest.java
@@ -5,7 +5,7 @@ import static com.google.common.truth.Truth.assertThat;
 import com.williamfiset.algorithms.utils.TestUtils;
 import java.util.Arrays;
 import java.util.EnumSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 // Test all sorting algorithms under various constraints.
 //

--- a/src/test/java/com/williamfiset/algorithms/strings/BoyerMooreStringSearchTest.java
+++ b/src/test/java/com/williamfiset/algorithms/strings/BoyerMooreStringSearchTest.java
@@ -6,8 +6,8 @@ import static java.util.Objects.isNull;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.api.*;
 
 public class BoyerMooreStringSearchTest {
 
@@ -15,7 +15,7 @@ public class BoyerMooreStringSearchTest {
   private Random random;
   private final int MAX_ITERATION = 20;
 
-  @Before
+  @BeforeEach
   public void setup() {
     underTest = new BoyerMooreStringSearch();
     random = new Random();

--- a/src/test/java/com/williamfiset/algorithms/strings/BoyerMooreStringSearchTest.java
+++ b/src/test/java/com/williamfiset/algorithms/strings/BoyerMooreStringSearchTest.java
@@ -6,7 +6,6 @@ import static java.util.Objects.isNull;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
-
 import org.junit.jupiter.api.*;
 
 public class BoyerMooreStringSearchTest {

--- a/src/test/java/com/williamfiset/algorithms/strings/LongestCommonSubstringTest.java
+++ b/src/test/java/com/williamfiset/algorithms/strings/LongestCommonSubstringTest.java
@@ -6,10 +6,11 @@ package com.williamfiset.algorithms.strings;
 import static com.google.common.truth.Truth.assertThat;
 import static com.williamfiset.algorithms.strings.LongestCommonSubstring.LcsSolver;
 
+import java.util.*;
+
 import com.google.common.collect.ImmutableList;
 import com.williamfiset.algorithms.utils.TestUtils;
-import java.util.*;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 public class LongestCommonSubstringTest {
 

--- a/src/test/java/com/williamfiset/algorithms/strings/LongestCommonSubstringTest.java
+++ b/src/test/java/com/williamfiset/algorithms/strings/LongestCommonSubstringTest.java
@@ -6,10 +6,9 @@ package com.williamfiset.algorithms.strings;
 import static com.google.common.truth.Truth.assertThat;
 import static com.williamfiset.algorithms.strings.LongestCommonSubstring.LcsSolver;
 
-import java.util.*;
-
 import com.google.common.collect.ImmutableList;
 import com.williamfiset.algorithms.utils.TestUtils;
+import java.util.*;
 import org.junit.jupiter.api.*;
 
 public class LongestCommonSubstringTest {

--- a/src/test/java/com/williamfiset/algorithms/strings/ZAlgorithmTest.java
+++ b/src/test/java/com/williamfiset/algorithms/strings/ZAlgorithmTest.java
@@ -2,13 +2,12 @@ package com.williamfiset.algorithms.strings;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
 
 public class ZAlgorithmTest {
   private ZAlgorithm underTest;
 
-  @Before
+  @BeforeEach
   public void setup() {
     underTest = new ZAlgorithm();
   }


### PR DESCRIPTION
https://github.com/williamfiset/Algorithms/blob/09a4f3b6f39d84879a8dc05d438a0f78234249b0/build.gradle#L16-L17

> As long as I don't start using Gradle and this plugin again myself, it's maybe better for everybody to state that **no, this project is _not_ maintained**. :sob:
> 
> _Originally posted in https://github.com/sherter/google-java-format-gradle-plugin/issues/57#issuecomment-782886280_

The old formatting tool is no longer maintained, as mentioned by the author of the tool (see above). Thus, this PR proposes restoring the formatting check by migrating to [Spotless for Gradle](https://github.com/diffplug/spotless/tree/main/plugin-gradle).

Unfortunate side effect: because Spotless for Gradle requires JDK 11+, the JDK version this repository is targeting (or equivalently, the JDK version used in CI) needs to be bumped up from JDK 8 to JDK 11+; see 28e7a1b (part of the reason this PR was a draft). @williamfiset any thoughts?