### PR TITLE
Reenable JUnit Platform

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,10 @@ test {
   testLogging.showStandardStreams = true
 }
 
+tasks.named('test', Test) {
+  useJUnitPlatform()
+}
+
 tasks.withType(JavaCompile) {
   options.encoding = 'UTF-8'
   options.compilerArgs += [


### PR DESCRIPTION
Related: #381 (cause of regression)

This was a clear oversight from me - turns out that to use JUnit 5 with Gradle you must specify to use JUnit Platform for testing (see [documentation](https://docs.gradle.org/current/userguide/java_testing.html#using_junit5)). Omitting this made the code to regress since #381 and running `./gradlew test` did _not_ run any tests (more precisely, none of the test classes were picked up for testing).

This PR fixes this regression.