### PR TITLE
Update Workflows / Dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,8 @@ updates:
   - package-ecosystem: "github-actions" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -24,7 +24,6 @@ jobs:
       with:
         java-version: 11
         distribution: 'temurin'
-        cache: 'gradle'
     - name: Validate Gradle Wrapper
       uses: gradle/wrapper-validation-action@v1
     - name: Setup and execute tests via Gradle
@@ -51,7 +50,6 @@ jobs:
       with:
         java-version: 11
         distribution: 'temurin'
-        cache: 'gradle'
     - name: Validate Gradle Wrapper
       uses: gradle/wrapper-validation-action@v1
     - name: Verify all Java files are formatted correctly according to the Google Java Style Guide using Gradle

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 
 plugins {
   // https://github.com/diffplug/spotless
-  id("com.diffplug.spotless") version "6.18.0"
+  id("com.diffplug.spotless") version "6.20.0"
 }
 
 apply plugin: 'java'
@@ -25,14 +25,14 @@ repositories {
 // 'compile' for project dependencies.
 dependencies {
   // Apache commons lang
-  testImplementation 'org.apache.commons:commons-lang3:3.12.0'
+  testImplementation 'org.apache.commons:commons-lang3:3.13.0'
 
   // JUnit 5 / Jupiter
-  testImplementation('org.junit.jupiter:junit-jupiter:5.9.3')
-  testRuntimeOnly('org.junit.jupiter:junit-jupiter-engine:5.9.3')
+  testImplementation('org.junit.jupiter:junit-jupiter:5.10.0')
+  testRuntimeOnly('org.junit.jupiter:junit-jupiter-engine:5.10.0')
 
   // Google Guava lib
-  testImplementation group: 'com.google.guava', name: 'guava', version: '23.0'
+  testImplementation group: 'com.google.guava', name: 'guava', version: '32.1.2-jre'
 
   // Google Truth test framework
   // https://mvnrepository.com/artifact/com.google.truth/truth

--- a/src/main/java/com/williamfiset/algorithms/datastructures/balancedtree/TreapTree.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/balancedtree/TreapTree.java
@@ -57,6 +57,7 @@ public class TreapTree<T extends Comparable<T>> {
       return value.toString();
     }
   }
+
   // The root node of the Treap tree.
   public Node root;
 

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/Boruvkas.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/Boruvkas.java
@@ -17,6 +17,7 @@ public class Boruvkas {
     public String toString() {
       return String.format("%d %d, cost: %d", u, v, cost);
     }
+
     // @Override
     public int compareTo(Edge other) {
       int cmp = cost - other.cost;

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/KruskalsEdgeListPartialSortSolver.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/KruskalsEdgeListPartialSortSolver.java
@@ -17,12 +17,14 @@ public class KruskalsEdgeListPartialSortSolver {
 
   static class Edge implements Comparable<Edge> {
     int u, v, cost;
+
     // 'u' and 'v' are nodes indexes and 'cost' is the cost of taking this edge.
     public Edge(int u, int v, int cost) {
       this.u = u;
       this.v = v;
       this.cost = cost;
     }
+
     // Sort edges based on cost.
     @Override
     public int compareTo(Edge other) {

--- a/src/test/java/com/williamfiset/algorithms/datastructures/priorityqueue/MinDHeapTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/priorityqueue/MinDHeapTest.java
@@ -195,6 +195,7 @@ public class MinDHeapTest {
     assertThat(pq.poll()).isEqualTo(11);
     assertThat(pq.poll()).isEqualTo(13);
   }
+
   /*
   @Test
   public void testRandomizedPolling() {


### PR DESCRIPTION
This PR:

- Disables caching by `actions/setup-java`  
  `gradle/build-gradle-action` provides a finer-grain caching (enabled by default) than `actions/setup-java` does.
- Configures [Dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates) for automated dependency updates
- Manually bumps up dependencies
  - Bumps up `commons-lang3` from 3.12.0 to 3.13.0
  - Bumps up JUnit 5 dependencies from 5.9.3 to 5.10.0
  - Bumps up `guava` from 23.0 to 32.1.2-jre
  - Bumps up `spotless` from 6.18.0 to 6.20.0 (and reapplies coding style with the updated version)