### PR TITLE
Refactor Graph Code

### DIFF
--- a/src/main/java/com/williamfiset/algorithms/graphtheory/AStar_GridHeuristic.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/AStar_GridHeuristic.java
@@ -7,20 +7,10 @@ public class AStar_GridHeuristic {
 
   // An edge class to represent a directed edge
   // between two nodes with a certain non-negative cost.
-  static class Edge {
-    double cost;
-    int from, to;
+  static class NonNegativeCostEdge extends WeightedEdge<Double> {
 
-    public Edge(int from, int to, double cost) {
-      if (cost < 0) throw new IllegalArgumentException("No negative edge weights");
-      this.from = from;
-      this.to = to;
-      this.cost = cost;
-    }
-
-    @Override
-    public String toString() {
-      return from + ":" + to;
+    public NonNegativeCostEdge(int from, int to, double cost) {
+      super(from, to, cost, c -> c >= 0d);
     }
   }
 
@@ -55,7 +45,12 @@ public class AStar_GridHeuristic {
   // starting node and the destination node the returned value is set to be
   // Double.POSITIVE_INFINITY.
   public static double astar(
-      double[] X, double[] Y, Map<Integer, List<Edge>> graph, int start, int end, int n) {
+      double[] X,
+      double[] Y,
+      Map<Integer, List<NonNegativeCostEdge>> graph,
+      int start,
+      int end,
+      int n) {
 
     // In the event that you wish to rebuild the shortest path
     // you can do so using the prev array and starting at some node 'end'
@@ -87,24 +82,24 @@ public class AStar_GridHeuristic {
 
       if (node.id == end) return G[end];
 
-      List<Edge> edges = graph.get(node.id);
+      List<NonNegativeCostEdge> edges = graph.get(node.id);
       if (edges != null) {
         for (int i = 0; i < edges.size(); i++) {
 
-          Edge edge = edges.get(i);
-          if (closedSet.contains(edge.to)) continue;
+          NonNegativeCostEdge edge = edges.get(i);
+          if (closedSet.contains(edge.getTo())) continue;
 
-          double g = node.g + edge.cost;
-          double h = heuristic(X, Y, edge.to, end);
+          double g = node.g + edge.getCost();
+          double h = heuristic(X, Y, edge.getTo(), end);
 
-          if (g < G[edge.to] || !openSet.contains(edge.to)) {
+          if (g < G[edge.getTo()] || !openSet.contains(edge.getTo())) {
 
-            G[edge.to] = g;
+            G[edge.getTo()] = g;
             // prev[edge.to] = edge.from;
 
-            if (!openSet.contains(edge.to)) {
-              pq.offer(new Node(edge.to, g, h));
-              openSet.add(edge.to);
+            if (!openSet.contains(edge.getTo())) {
+              pq.offer(new Node(edge.getTo(), g, h));
+              openSet.add(edge.getTo());
             }
           }
         }
@@ -130,7 +125,7 @@ public class AStar_GridHeuristic {
     Random RANDOM = new Random();
 
     int n = 20 * 20;
-    Map<Integer, List<Edge>> graph = new HashMap<>();
+    Map<Integer, List<NonNegativeCostEdge>> graph = new HashMap<>();
     for (int i = 0; i < n; i++) graph.put(i, new ArrayList<>());
 
     double[] X = new double[n];
@@ -185,10 +180,10 @@ public class AStar_GridHeuristic {
   }
 
   static void addEdge(
-      Map<Integer, List<Edge>> graph, int f, int t, int fx, int fy, int tx, int ty) {
+      Map<Integer, List<NonNegativeCostEdge>> graph, int f, int t, int fx, int fy, int tx, int ty) {
     double dx = Math.abs(fx - tx);
     double dy = Math.abs(fy - ty);
-    graph.get(f).add(new Edge(f, t, dx + dy));
+    graph.get(f).add(new NonNegativeCostEdge(f, t, dx + dy));
   }
 
   // Node class to track the nodes to visit while running Dijkstra's
@@ -213,7 +208,8 @@ public class AStar_GridHeuristic {
   // from a starting node to an ending node. If there is no path between the
   // starting node and the destination node the returned value is set to be
   // Double.POSITIVE_INFINITY.
-  public static double dijkstra(Map<Integer, List<Edge>> graph, int start, int end, int n) {
+  public static double dijkstra(
+      Map<Integer, List<NonNegativeCostEdge>> graph, int start, int end, int n) {
 
     // Maintain an array of the minimum distance to each node
     double[] dists = new double[n];
@@ -243,21 +239,21 @@ public class AStar_GridHeuristic {
       // processing this node so we can ignore it.
       if (node.value > dists[node.id]) continue;
 
-      List<Edge> edges = graph.get(node.id);
+      List<NonNegativeCostEdge> edges = graph.get(node.id);
       if (edges != null) {
         for (int i = 0; i < edges.size(); i++) {
-          Edge edge = edges.get(i);
+          NonNegativeCostEdge edge = edges.get(i);
 
           // You cannot get a shorter path by revisiting
           // a node you have already visited before
-          if (visited[edge.to]) continue;
+          if (visited[edge.getTo()]) continue;
 
           // Update minimum cost if applicable
-          double newDist = dists[edge.from] + edge.cost;
-          if (newDist < dists[edge.to]) {
-            // prev[edge.to] = edge.from;
-            dists[edge.to] = newDist;
-            pq.offer(new DNode(edge.to, dists[edge.to]));
+          double newDist = dists[edge.getFrom()] + edge.getCost();
+          if (newDist < dists[edge.getTo()]) {
+            // prev[edge.getTo()] = edge.getFrom();
+            dists[edge.getTo()] = newDist;
+            pq.offer(new DNode(edge.getTo(), dists[edge.getTo()]));
           }
         }
       }

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/BellmanFordEdgeList.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/BellmanFordEdgeList.java
@@ -8,18 +8,6 @@ package com.williamfiset.algorithms.graphtheory;
 
 public class BellmanFordEdgeList {
 
-  // A directed edge
-  public static class Edge {
-    double cost;
-    int from, to;
-
-    public Edge(int from, int to, double cost) {
-      this.to = to;
-      this.from = from;
-      this.cost = cost;
-    }
-  }
-
   /**
    * An implementation of the Bellman-Ford algorithm. The algorithm finds the shortest path between
    * a starting node and all other nodes in the graph. The algorithm also detects negative cycles.
@@ -30,7 +18,7 @@ public class BellmanFordEdgeList {
    * @param V - The number of vertices in the graph.
    * @param start - The id of the starting node
    */
-  public static double[] bellmanFord(Edge[] edges, int V, int start) {
+  public static double[] bellmanFord(WeightedEdge<Double>[] edges, int V, int start) {
 
     double[] dist = new double[V];
     java.util.Arrays.fill(dist, Double.POSITIVE_INFINITY);
@@ -44,9 +32,9 @@ public class BellmanFordEdgeList {
     // For each vertex, apply relaxation for all the edges
     for (int v = 0; v < V - 1 && relaxedAnEdge; v++) {
       relaxedAnEdge = false;
-      for (Edge edge : edges) {
-        if (dist[edge.from] + edge.cost < dist[edge.to]) {
-          dist[edge.to] = dist[edge.from] + edge.cost;
+      for (WeightedEdge<Double> edge : edges) {
+        if (dist[edge.getFrom()] + edge.getCost() < dist[edge.getTo()]) {
+          dist[edge.getTo()] = dist[edge.getFrom()] + edge.getCost();
           relaxedAnEdge = true;
         }
       }
@@ -58,9 +46,9 @@ public class BellmanFordEdgeList {
     relaxedAnEdge = true;
     for (int v = 0; v < V - 1 && relaxedAnEdge; v++) {
       relaxedAnEdge = false;
-      for (Edge edge : edges) {
-        if (dist[edge.from] + edge.cost < dist[edge.to]) {
-          dist[edge.to] = Double.NEGATIVE_INFINITY;
+      for (WeightedEdge<Double> edge : edges) {
+        if (dist[edge.getFrom()] + edge.getCost() < dist[edge.getTo()]) {
+          dist[edge.getTo()] = Double.NEGATIVE_INFINITY;
           relaxedAnEdge = true;
         }
       }
@@ -70,20 +58,21 @@ public class BellmanFordEdgeList {
     return dist;
   }
 
+  @SuppressWarnings("unchecked")
   public static void main(String[] args) {
 
     int E = 10, V = 9, start = 0;
-    Edge[] edges = new Edge[E];
-    edges[0] = new Edge(0, 1, 1);
-    edges[1] = new Edge(1, 2, 1);
-    edges[2] = new Edge(2, 4, 1);
-    edges[3] = new Edge(4, 3, -3);
-    edges[4] = new Edge(3, 2, 1);
-    edges[5] = new Edge(1, 5, 4);
-    edges[6] = new Edge(1, 6, 4);
-    edges[7] = new Edge(5, 6, 5);
-    edges[8] = new Edge(6, 7, 4);
-    edges[9] = new Edge(5, 7, 3);
+    WeightedEdge<Double>[] edges = new WeightedEdge[E];
+    edges[0] = new WeightedEdge<>(0, 1, 1d);
+    edges[1] = new WeightedEdge<>(1, 2, 1d);
+    edges[2] = new WeightedEdge<>(2, 4, 1d);
+    edges[3] = new WeightedEdge<>(4, 3, -3d);
+    edges[4] = new WeightedEdge<>(3, 2, 1d);
+    edges[5] = new WeightedEdge<>(1, 5, 4d);
+    edges[6] = new WeightedEdge<>(1, 6, 4d);
+    edges[7] = new WeightedEdge<>(5, 6, 5d);
+    edges[8] = new WeightedEdge<>(6, 7, 4d);
+    edges[9] = new WeightedEdge<>(5, 7, 3d);
 
     double[] d = bellmanFord(edges, V, start);
 

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/BreadthFirstSearchAdjacencyListIterative.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/BreadthFirstSearchAdjacencyListIterative.java
@@ -15,21 +15,11 @@ import java.util.List;
 
 public class BreadthFirstSearchAdjacencyListIterative {
 
-  public static class Edge {
-    int from, to, cost;
-
-    public Edge(int from, int to, int cost) {
-      this.from = from;
-      this.to = to;
-      this.cost = cost;
-    }
-  }
-
   private int n;
   private Integer[] prev;
-  private List<List<Edge>> graph;
+  private List<List<WeightedEdge<Integer>>> graph;
 
-  public BreadthFirstSearchAdjacencyListIterative(List<List<Edge>> graph) {
+  public BreadthFirstSearchAdjacencyListIterative(List<List<WeightedEdge<Integer>>> graph) {
     if (graph == null) throw new IllegalArgumentException("Graph can not be null");
     n = graph.size();
     this.graph = graph;
@@ -65,41 +55,44 @@ public class BreadthFirstSearchAdjacencyListIterative {
     // Continue until the BFS is done.
     while (!queue.isEmpty()) {
       int node = queue.poll();
-      List<Edge> edges = graph.get(node);
+      List<WeightedEdge<Integer>> edges = graph.get(node);
 
       // Loop through all edges attached to this node. Mark nodes as visited once they're
       // in the queue. This will prevent having duplicate nodes in the queue and speedup the BFS.
-      for (Edge edge : edges) {
-        if (!visited[edge.to]) {
-          visited[edge.to] = true;
-          prev[edge.to] = node;
-          queue.offer(edge.to);
+      for (WeightedEdge<Integer> edge : edges) {
+        if (!visited[edge.getTo()]) {
+          visited[edge.getTo()] = true;
+          prev[edge.getTo()] = node;
+          queue.offer(edge.getTo());
         }
       }
     }
   }
 
   // Initialize an empty adjacency list that can hold up to n nodes.
-  public static List<List<Edge>> createEmptyGraph(int n) {
-    List<List<Edge>> graph = new ArrayList<>(n);
+  public static List<List<WeightedEdge<Integer>>> createEmptyGraph(int n) {
+    List<List<WeightedEdge<Integer>>> graph = new ArrayList<>(n);
     for (int i = 0; i < n; i++) graph.add(new ArrayList<>());
     return graph;
   }
 
   // Add a directed edge from node 'u' to node 'v' with cost 'cost'.
-  public static void addDirectedEdge(List<List<Edge>> graph, int u, int v, int cost) {
-    graph.get(u).add(new Edge(u, v, cost));
+  public static void addDirectedEdge(
+      List<List<WeightedEdge<Integer>>> graph, int u, int v, int cost) {
+    graph.get(u).add(new WeightedEdge<>(u, v, cost));
   }
 
   // Add an undirected edge between nodes 'u' and 'v'.
-  public static void addUndirectedEdge(List<List<Edge>> graph, int u, int v, int cost) {
+  public static void addUndirectedEdge(
+      List<List<WeightedEdge<Integer>>> graph, int u, int v, int cost) {
     addDirectedEdge(graph, u, v, cost);
     addDirectedEdge(graph, v, u, cost);
   }
 
   // Add an undirected unweighted edge between nodes 'u' and 'v'. The edge added
   // will have a weight of 1 since its intended to be unweighted.
-  public static void addUnweightedUndirectedEdge(List<List<Edge>> graph, int u, int v) {
+  public static void addUnweightedUndirectedEdge(
+      List<List<WeightedEdge<Integer>>> graph, int u, int v) {
     addUndirectedEdge(graph, u, v, 1);
   }
 
@@ -108,7 +101,7 @@ public class BreadthFirstSearchAdjacencyListIterative {
   public static void main(String[] args) {
     // BFS example #1 from slides.
     final int n = 13;
-    List<List<Edge>> graph = createEmptyGraph(n);
+    List<List<WeightedEdge<Integer>>> graph = createEmptyGraph(n);
 
     addUnweightedUndirectedEdge(graph, 0, 7);
     addUnweightedUndirectedEdge(graph, 0, 9);

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/BreadthFirstSearchAdjacencyListIterativeFastQueue.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/BreadthFirstSearchAdjacencyListIterativeFastQueue.java
@@ -50,20 +50,10 @@ class IntQueue {
 
 public class BreadthFirstSearchAdjacencyListIterativeFastQueue {
 
-  static class Edge {
-    int from, to, cost;
-
-    public Edge(int from, int to, int cost) {
-      this.from = from;
-      this.to = to;
-      this.cost = cost;
-    }
-  }
-
   // Perform a breadth first search on a graph with n nodes
   // from a starting point to count the number of nodes
   // in a given component.
-  static int bfs(Map<Integer, List<Edge>> graph, int start, int n) {
+  static int bfs(Map<Integer, List<WeightedEdge<Integer>>> graph, int start, int n) {
 
     int count = 0;
     boolean[] visited = new boolean[n];
@@ -99,16 +89,16 @@ public class BreadthFirstSearchAdjacencyListIterativeFastQueue {
 
         count++;
 
-        List<Edge> edges = graph.get(node);
+        List<WeightedEdge<Integer>> edges = graph.get(node);
         if (edges != null) {
 
           // Loop through all edges attached to this node. Mark nodes as
           // visited once they're in the queue. This will prevent having
           // duplicate nodes in the queue and speedup the BFS.
-          for (Edge edge : edges) {
-            if (!visited[edge.to]) {
-              visited[edge.to] = true;
-              queue.enqueue(edge.to);
+          for (WeightedEdge<Integer> edge : edges) {
+            if (!visited[edge.getTo()]) {
+              visited[edge.getTo()] = true;
+              queue.enqueue(edge.getTo());
             }
           }
         }
@@ -123,7 +113,7 @@ public class BreadthFirstSearchAdjacencyListIterativeFastQueue {
 
     // Create a fully connected graph
     int numNodes = 8;
-    Map<Integer, List<Edge>> graph = new HashMap<>();
+    Map<Integer, List<WeightedEdge<Integer>>> graph = new HashMap<>();
     addDirectedEdge(graph, 1, 2, 1);
     addDirectedEdge(graph, 1, 2, 1); // Double edge
     addDirectedEdge(graph, 1, 3, 1);
@@ -154,12 +144,13 @@ public class BreadthFirstSearchAdjacencyListIterativeFastQueue {
   }
 
   // Helper method to setup graph
-  private static void addDirectedEdge(Map<Integer, List<Edge>> graph, int from, int to, int cost) {
-    List<Edge> list = graph.get(from);
+  private static void addDirectedEdge(
+      Map<Integer, List<WeightedEdge<Integer>>> graph, int from, int to, int cost) {
+    List<WeightedEdge<Integer>> list = graph.get(from);
     if (list == null) {
-      list = new ArrayList<Edge>();
+      list = new ArrayList<WeightedEdge<Integer>>();
       graph.put(from, list);
     }
-    list.add(new Edge(from, to, cost));
+    list.add(new WeightedEdge<>(from, to, cost));
   }
 }

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/ConnectedComponentsAdjacencyList.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/ConnectedComponentsAdjacencyList.java
@@ -16,25 +16,15 @@ import java.util.*;
 
 public class ConnectedComponentsAdjacencyList {
 
-  static class Edge {
-    int from, to, cost;
-
-    public Edge(int from, int to, int cost) {
-      this.from = from;
-      this.to = to;
-      this.cost = cost;
-    }
-  }
-
-  static int countConnectedComponents(Map<Integer, List<Edge>> graph, int n) {
+  static int countConnectedComponents(Map<Integer, List<WeightedEdge<Integer>>> graph, int n) {
 
     UnionFind uf = new UnionFind(n);
 
     for (int i = 0; i < n; i++) {
-      List<Edge> edges = graph.get(i);
+      List<WeightedEdge<Integer>> edges = graph.get(i);
       if (edges != null) {
-        for (Edge edge : edges) {
-          uf.unify(edge.from, edge.to);
+        for (WeightedEdge<Integer> edge : edges) {
+          uf.unify(edge.getFrom(), edge.getTo());
         }
       }
     }
@@ -46,7 +36,7 @@ public class ConnectedComponentsAdjacencyList {
   public static void main(String[] args) {
 
     final int numNodes = 7;
-    Map<Integer, List<Edge>> graph = new HashMap<>();
+    Map<Integer, List<WeightedEdge<Integer>>> graph = new HashMap<>();
 
     // Setup a graph with four connected components
     // namely: {0,1,2}, {3,4}, {5}, {6}
@@ -62,14 +52,14 @@ public class ConnectedComponentsAdjacencyList {
 
   // Helper method to setup graph
   private static void addUndirectedEdge(
-      Map<Integer, List<Edge>> graph, int from, int to, int cost) {
-    List<Edge> list = graph.get(from);
+      Map<Integer, List<WeightedEdge<Integer>>> graph, int from, int to, int cost) {
+    List<WeightedEdge<Integer>> list = graph.get(from);
     if (list == null) {
-      list = new ArrayList<Edge>();
+      list = new ArrayList<WeightedEdge<Integer>>();
       graph.put(from, list);
     }
-    list.add(new Edge(from, to, cost));
-    list.add(new Edge(to, from, cost));
+    list.add(new WeightedEdge<>(from, to, cost));
+    list.add(new WeightedEdge<>(to, from, cost));
   }
 }
 

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/CostComparingEdge.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/CostComparingEdge.java
@@ -1,0 +1,35 @@
+package com.williamfiset.algorithms.graphtheory;
+
+/**
+ * A type of weighted edge whose weight is an integer and the ordering is defined by its weight
+ * (cost).
+ *
+ * @author Sung Ho Yoon
+ */
+public class CostComparingEdge extends WeightedEdge<Integer>
+    implements Comparable<CostComparingEdge> {
+  /**
+   * Constructs a {@code CostComparingEdge}.
+   *
+   * @param from the source node
+   * @param to the destination node
+   * @param cost the cost associated with the edge
+   */
+  public CostComparingEdge(int from, int to, int cost) {
+    super(from, to, cost);
+  }
+
+  /**
+   * Compares this edge with the specified edge for order. If the weights of the two edges are
+   * equal, then the ordering is determined by natural ordering of the source and destination nodes.
+   *
+   * @return a negative integer, zero, or a positive integer as this object is less than, equal to,
+   *     or greater than the specified edge
+   */
+  @Override
+  public int compareTo(CostComparingEdge other) {
+    if (getCost() != other.getCost()) return getCost() - other.getCost();
+    if (getFrom() != other.getFrom()) return getFrom() - other.getFrom();
+    return getTo() - other.getTo();
+  }
+}

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/DepthFirstSearchAdjacencyListIterative.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/DepthFirstSearchAdjacencyListIterative.java
@@ -9,20 +9,10 @@ import java.util.*;
 
 public class DepthFirstSearchAdjacencyListIterative {
 
-  static class Edge {
-    int from, to, cost;
-
-    public Edge(int from, int to, int cost) {
-      this.from = from;
-      this.to = to;
-      this.cost = cost;
-    }
-  }
-
   // Perform a depth first search on a graph with n nodes
   // from a starting point to count the number of nodes
   // in a given component.
-  static int dfs(Map<Integer, List<Edge>> graph, int start, int n) {
+  static int dfs(Map<Integer, List<WeightedEdge<Integer>>> graph, int start, int n) {
 
     int count = 0;
     boolean[] visited = new boolean[n];
@@ -35,13 +25,13 @@ public class DepthFirstSearchAdjacencyListIterative {
     while (!stack.isEmpty()) {
       int node = stack.pop();
       count++;
-      List<Edge> edges = graph.get(node);
+      List<WeightedEdge<Integer>> edges = graph.get(node);
 
       if (edges != null) {
-        for (Edge edge : edges) {
-          if (!visited[edge.to]) {
-            stack.push(edge.to);
-            visited[edge.to] = true;
+        for (WeightedEdge<Integer> edge : edges) {
+          if (!visited[edge.getTo()]) {
+            stack.push(edge.getTo());
+            visited[edge.getTo()] = true;
           }
         }
       }
@@ -54,19 +44,19 @@ public class DepthFirstSearchAdjacencyListIterative {
   public static void main(String[] args) {
 
     // Create a fully connected graph
-    //           (0)
-    //           / \
-    //        5 /   \ 4
-    //         /     \
-    // 10     <   -2  >
-    //   +->(2)<------(1)      (4)
-    //   +--- \       /
-    //         \     /
-    //        1 \   / 6
-    //           > <
-    //           (3)
+    // (0)
+    // / \
+    // 5 / \ 4
+    // / \
+    // 10 < -2 >
+    // +->(2)<------(1) (4)
+    // +--- \ /
+    // \ /
+    // 1 \ / 6
+    // > <
+    // (3)
     int numNodes = 5;
-    Map<Integer, List<Edge>> graph = new HashMap<>();
+    Map<Integer, List<WeightedEdge<Integer>>> graph = new HashMap<>();
     addDirectedEdge(graph, 0, 1, 4);
     addDirectedEdge(graph, 0, 2, 5);
     addDirectedEdge(graph, 1, 2, -2);
@@ -84,12 +74,13 @@ public class DepthFirstSearchAdjacencyListIterative {
   }
 
   // Helper method to setup graph
-  private static void addDirectedEdge(Map<Integer, List<Edge>> graph, int from, int to, int cost) {
-    List<Edge> list = graph.get(from);
+  private static void addDirectedEdge(
+      Map<Integer, List<WeightedEdge<Integer>>> graph, int from, int to, int cost) {
+    List<WeightedEdge<Integer>> list = graph.get(from);
     if (list == null) {
-      list = new ArrayList<Edge>();
+      list = new ArrayList<WeightedEdge<Integer>>();
       graph.put(from, list);
     }
-    list.add(new Edge(from, to, cost));
+    list.add(new WeightedEdge<>(from, to, cost));
   }
 }

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/DepthFirstSearchAdjacencyListIterativeFastStack.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/DepthFirstSearchAdjacencyListIterativeFastStack.java
@@ -6,25 +6,15 @@
  */
 package com.williamfiset.algorithms.graphtheory;
 
-import java.util.*;
 import com.williamfiset.algorithms.datastructures.stack.IntStack;
+import java.util.*;
 
 public class DepthFirstSearchAdjacencyListIterativeFastStack {
-
-  static class Edge {
-    int from, to, cost;
-
-    public Edge(int from, int to, int cost) {
-      this.from = from;
-      this.to = to;
-      this.cost = cost;
-    }
-  }
 
   // Perform a depth first search on a graph with n nodes
   // from a starting point to count the number of nodes
   // in a given component.
-  static int dfs(Map<Integer, List<Edge>> graph, int start, int n) {
+  static int dfs(Map<Integer, List<WeightedEdge<Integer>>> graph, int start, int n) {
 
     int count = 0;
     boolean[] visited = new boolean[n];
@@ -39,12 +29,12 @@ public class DepthFirstSearchAdjacencyListIterativeFastStack {
 
         count++;
         visited[node] = true;
-        List<Edge> edges = graph.get(node);
+        List<WeightedEdge<Integer>> edges = graph.get(node);
 
         if (edges != null) {
-          for (Edge edge : edges) {
-            if (!visited[edge.to]) {
-              stack.push(edge.to);
+          for (WeightedEdge<Integer> edge : edges) {
+            if (!visited[edge.getTo()]) {
+              stack.push(edge.getTo());
             }
           }
         }
@@ -58,19 +48,19 @@ public class DepthFirstSearchAdjacencyListIterativeFastStack {
   public static void main(String[] args) {
 
     // Create a fully connected graph
-    //           (0)
-    //           / \
-    //        5 /   \ 4
-    //         /     \
-    // 10     <   -2  >
-    //   +->(2)<------(1)      (4)
-    //   +--- \       /
-    //         \     /
-    //        1 \   / 6
-    //           > <
-    //           (3)
+    // (0)
+    // / \
+    // 5 / \ 4
+    // / \
+    // 10 < -2 >
+    // +->(2)<------(1) (4)
+    // +--- \ /
+    // \ /
+    // 1 \ / 6
+    // > <
+    // (3)
     int numNodes = 5;
-    Map<Integer, List<Edge>> graph = new HashMap<>();
+    Map<Integer, List<WeightedEdge<Integer>>> graph = new HashMap<>();
     addDirectedEdge(graph, 0, 1, 4);
     addDirectedEdge(graph, 0, 2, 5);
     addDirectedEdge(graph, 1, 2, -2);
@@ -88,12 +78,13 @@ public class DepthFirstSearchAdjacencyListIterativeFastStack {
   }
 
   // Helper method to setup graph
-  private static void addDirectedEdge(Map<Integer, List<Edge>> graph, int from, int to, int cost) {
-    List<Edge> list = graph.get(from);
+  private static void addDirectedEdge(
+      Map<Integer, List<WeightedEdge<Integer>>> graph, int from, int to, int cost) {
+    List<WeightedEdge<Integer>> list = graph.get(from);
     if (list == null) {
-      list = new ArrayList<Edge>();
+      list = new ArrayList<WeightedEdge<Integer>>();
       graph.put(from, list);
     }
-    list.add(new Edge(from, to, cost));
+    list.add(new WeightedEdge<>(from, to, cost));
   }
 }

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/DepthFirstSearchAdjacencyListIterativeFastStack.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/DepthFirstSearchAdjacencyListIterativeFastStack.java
@@ -7,42 +7,7 @@
 package com.williamfiset.algorithms.graphtheory;
 
 import java.util.*;
-
-// This file contains an implementation of an integer only stack which is
-// extremely quick and lightweight. In terms of performance it can outperform
-// java.util.ArrayDeque (Java's fastest stack implementation) by a factor of 50!
-// However, the downside is you need to know an upper bound on the number of
-// elements that will be inside the stack at any given time for it to work correctly.
-class IntStack {
-
-  private int[] ar;
-  private int pos = 0, sz;
-
-  // max_sz is the maximum number of items
-  // that can be in the queue at any given time
-  public IntStack(int max_sz) {
-    ar = new int[(sz = max_sz)];
-  }
-
-  public boolean isEmpty() {
-    return pos == 0;
-  }
-
-  // Returns the element at the top of the stack
-  public int peek() {
-    return ar[pos - 1];
-  }
-
-  // Add an element to the top of the stack
-  public void push(int value) {
-    ar[pos++] = value;
-  }
-
-  // Make sure you check that the stack is not empty before calling pop!
-  public int pop() {
-    return ar[--pos];
-  }
-}
+import com.williamfiset.algorithms.datastructures.stack.IntStack;
 
 public class DepthFirstSearchAdjacencyListIterativeFastStack {
 

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/DepthFirstSearchAdjacencyListRecursive.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/DepthFirstSearchAdjacencyListRecursive.java
@@ -9,19 +9,9 @@ import java.util.*;
 
 public class DepthFirstSearchAdjacencyListRecursive {
 
-  static class Edge {
-    int from, to, cost;
-
-    public Edge(int from, int to, int cost) {
-      this.from = from;
-      this.to = to;
-      this.cost = cost;
-    }
-  }
-
   // Perform a depth first search on the graph counting
   // the number of nodes traversed starting at some position
-  static long dfs(int at, boolean[] visited, Map<Integer, List<Edge>> graph) {
+  static long dfs(int at, boolean[] visited, Map<Integer, List<WeightedEdge<Integer>>> graph) {
 
     // We have already visited this node
     if (visited[at]) return 0L;
@@ -31,10 +21,10 @@ public class DepthFirstSearchAdjacencyListRecursive {
     long count = 1;
 
     // Visit all edges adjacent to where we're at
-    List<Edge> edges = graph.get(at);
+    List<WeightedEdge<Integer>> edges = graph.get(at);
     if (edges != null) {
-      for (Edge edge : edges) {
-        count += dfs(edge.to, visited, graph);
+      for (WeightedEdge<Integer> edge : edges) {
+        count += dfs(edge.getTo(), visited, graph);
       }
     }
 
@@ -57,7 +47,7 @@ public class DepthFirstSearchAdjacencyListRecursive {
     //           > <
     //           (3)
     int numNodes = 5;
-    Map<Integer, List<Edge>> graph = new HashMap<>();
+    Map<Integer, List<WeightedEdge<Integer>>> graph = new HashMap<>();
     addDirectedEdge(graph, 0, 1, 4);
     addDirectedEdge(graph, 0, 2, 5);
     addDirectedEdge(graph, 1, 2, -2);
@@ -75,12 +65,13 @@ public class DepthFirstSearchAdjacencyListRecursive {
   }
 
   // Helper method to setup graph
-  private static void addDirectedEdge(Map<Integer, List<Edge>> graph, int from, int to, int cost) {
-    List<Edge> list = graph.get(from);
+  private static void addDirectedEdge(
+      Map<Integer, List<WeightedEdge<Integer>>> graph, int from, int to, int cost) {
+    List<WeightedEdge<Integer>> list = graph.get(from);
     if (list == null) {
-      list = new ArrayList<Edge>();
+      list = new ArrayList<WeightedEdge<Integer>>();
       graph.put(from, list);
     }
-    list.add(new Edge(from, to, cost));
+    list.add(new WeightedEdge<>(from, to, cost));
   }
 }

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/DijkstrasShortestPathAdjacencyList.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/DijkstrasShortestPathAdjacencyList.java
@@ -21,19 +21,6 @@ public class DijkstrasShortestPathAdjacencyList {
   // Small epsilon value to comparing double values.
   private static final double EPS = 1e-6;
 
-  // An edge class to represent a directed edge
-  // between two nodes with a certain cost.
-  public static class Edge {
-    double cost;
-    int from, to;
-
-    public Edge(int from, int to, double cost) {
-      this.from = from;
-      this.to = to;
-      this.cost = cost;
-    }
-  }
-
   // Node class to track the nodes to visit while running Dijkstra's
   public static class Node {
     int id;
@@ -48,7 +35,7 @@ public class DijkstrasShortestPathAdjacencyList {
   private int n;
   private double[] dist;
   private Integer[] prev;
-  private List<List<Edge>> graph;
+  private List<List<WeightedEdge<Double>>> graph;
 
   private Comparator<Node> comparator =
       new Comparator<Node>() {
@@ -83,13 +70,13 @@ public class DijkstrasShortestPathAdjacencyList {
    * @param to - The index of the node the directed edge end at.
    * @param cost - The cost of the edge.
    */
-  public void addEdge(int from, int to, int cost) {
-    graph.get(from).add(new Edge(from, to, cost));
+  public void addEdge(int from, int to, double cost) {
+    graph.get(from).add(new WeightedEdge<>(from, to, cost));
   }
 
   // Use {@link #addEdge} method to add edges to the graph and use this method
   // to retrieve the constructed graph.
-  public List<List<Edge>> getGraph() {
+  public List<List<WeightedEdge<Double>>> getGraph() {
     return graph;
   }
 
@@ -136,20 +123,20 @@ public class DijkstrasShortestPathAdjacencyList {
       // processing this node so we can ignore it.
       if (dist[node.id] < node.value) continue;
 
-      List<Edge> edges = graph.get(node.id);
+      List<WeightedEdge<Double>> edges = graph.get(node.id);
       for (int i = 0; i < edges.size(); i++) {
-        Edge edge = edges.get(i);
+        WeightedEdge<Double> edge = edges.get(i);
 
         // You cannot get a shorter path by revisiting
         // a node you have already visited before.
-        if (visited[edge.to]) continue;
+        if (visited[edge.getTo()]) continue;
 
         // Relax edge by updating minimum cost if applicable.
-        double newDist = dist[edge.from] + edge.cost;
-        if (newDist < dist[edge.to]) {
-          prev[edge.to] = edge.from;
-          dist[edge.to] = newDist;
-          pq.offer(new Node(edge.to, dist[edge.to]));
+        double newDist = dist[edge.getFrom()] + edge.getCost();
+        if (newDist < dist[edge.getTo()]) {
+          prev[edge.getTo()] = edge.getFrom();
+          dist[edge.getTo()] = newDist;
+          pq.offer(new Node(edge.getTo(), dist[edge.getTo()]));
         }
       }
       // Once we've visited all the nodes spanning from the end

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/Edge.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/Edge.java
@@ -1,0 +1,79 @@
+package com.williamfiset.algorithms.graphtheory;
+
+import java.util.Objects;
+
+/**
+ * A generic representation of an edge of a graph.
+ *
+ * @author Sung Ho Yoon
+ */
+public class Edge {
+  /** The source node */
+  private int from;
+
+  /** The destination node */
+  private int to;
+
+  /**
+   * Constructs a new {@code Edge}.
+   *
+   * @param from the source node
+   * @param to the destination node
+   */
+  public Edge(int from, int to) {
+    this.from = from;
+    this.to = to;
+  }
+
+  /**
+   * Returns the source node of this edge.
+   *
+   * @return the source node of this edge
+   */
+  public final int getFrom() {
+    return from;
+  }
+
+  /**
+   * Returns the destination node of this edge.
+   *
+   * @return the destination node of this edge
+   */
+  public final int getTo() {
+    return to;
+  }
+
+  /**
+   * Checks whether some object is "equal to" this edge.
+   *
+   * @return {@code true} if argument is equal to this edge
+   */
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) return true;
+    else if (obj instanceof Edge) {
+      Edge edge = (Edge) obj;
+      return this.from == edge.from && this.to == edge.to;
+    } else return false;
+  }
+
+  /**
+   * Returns a hash code value for this edge.
+   *
+   * @return a hash code value
+   */
+  @Override
+  public int hashCode() {
+    return Objects.hash(from, to);
+  }
+
+  /**
+   * Returns a string representation of this edge.
+   *
+   * @return a string representation of this edge
+   */
+  @Override
+  public String toString() {
+    return from + ":" + to;
+  }
+}

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/GraphDiameter.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/GraphDiameter.java
@@ -14,15 +14,6 @@ import java.util.*;
 
 public class GraphDiameter {
 
-  static class Edge {
-    int from, to;
-
-    public Edge(int from, int to) {
-      this.from = from;
-      this.to = to;
-    }
-  }
-
   // Separate each breadth first search layer with a DEPTH_TOKEN
   // to easily determine the distance to other nodes
   static final int DEPTH_TOKEN = -1;
@@ -68,9 +59,9 @@ public class GraphDiameter {
         List<Edge> edges = graph.get(id);
         if (edges != null) {
           for (Edge edge : edges) {
-            if (visited.get(edge.to) != VISITED_TOKEN) {
-              visited.put(edge.to, VISITED_TOKEN);
-              queue.offer(edge.to);
+            if (visited.get(edge.getTo()) != VISITED_TOKEN) {
+              visited.put(edge.getTo(), VISITED_TOKEN);
+              queue.offer(edge.getTo());
             }
           }
         }

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/KruskalsEdgeList.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/KruskalsEdgeList.java
@@ -54,25 +54,10 @@ public class KruskalsEdgeList {
     }
   }
 
-  static class Edge implements Comparable<Edge> {
-    int from, to, cost;
-
-    public Edge(int from, int to, int cost) {
-      this.from = from;
-      this.to = to;
-      this.cost = cost;
-    }
-
-    @Override
-    public int compareTo(Edge other) {
-      return cost - other.cost;
-    }
-  }
-
   // Given a graph represented as an edge list this method finds
   // the Minimum Spanning Tree (MST) cost if there exists
   // a MST, otherwise it returns null.
-  static Long kruskals(Edge[] edges, int n) {
+  static Long kruskals(CostComparingEdge[] edges, int n) {
 
     if (edges == null) return null;
 
@@ -80,14 +65,14 @@ public class KruskalsEdgeList {
     java.util.Arrays.sort(edges);
     UnionFind uf = new UnionFind(n);
 
-    for (Edge edge : edges) {
+    for (CostComparingEdge edge : edges) {
 
       // Skip this edge to avoid creating a cycle in MST
-      if (uf.connected(edge.from, edge.to)) continue;
+      if (uf.connected(edge.getFrom(), edge.getTo())) continue;
 
       // Include this edge
-      uf.union(edge.from, edge.to);
-      sum += edge.cost;
+      uf.union(edge.getFrom(), edge.getTo());
+      sum += edge.getCost();
 
       // Optimization to stop early if we found
       // a MST that includes all the nodes

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/KruskalsEdgeListPartialSortSolver.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/KruskalsEdgeListPartialSortSolver.java
@@ -15,45 +15,28 @@ import java.util.PriorityQueue;
 
 public class KruskalsEdgeListPartialSortSolver {
 
-  static class Edge implements Comparable<Edge> {
-    int u, v, cost;
-
-    // 'u' and 'v' are nodes indexes and 'cost' is the cost of taking this edge.
-    public Edge(int u, int v, int cost) {
-      this.u = u;
-      this.v = v;
-      this.cost = cost;
-    }
-
-    // Sort edges based on cost.
-    @Override
-    public int compareTo(Edge other) {
-      return cost - other.cost;
-    }
-  }
-
   // Inputs
   private int n;
-  private List<Edge> edges;
+  private List<CostComparingEdge> edges;
 
   // Internal
   private boolean solved;
   private boolean mstExists;
 
   // Outputs
-  private Edge[] mst;
+  private CostComparingEdge[] mst;
   private long mstCost;
 
   // edges - A list of undirected edges.
   // n     - The number of nodes in the input graph.
-  public KruskalsEdgeListPartialSortSolver(List<Edge> edges, int n) {
+  public KruskalsEdgeListPartialSortSolver(List<CostComparingEdge> edges, int n) {
     if (edges == null || n <= 1) throw new IllegalArgumentException();
     this.edges = edges;
     this.n = n;
   }
 
   // Gets the Minimum Spanning Tree (MST) of the input graph or null if no MST.
-  public Edge[] getMst() {
+  public CostComparingEdge[] getMst() {
     kruskals();
     return mstExists ? mst : null;
   }
@@ -68,23 +51,23 @@ public class KruskalsEdgeListPartialSortSolver {
     if (solved) return;
 
     // Heapify operation in constructor transforms list of edges into a binary heap in O(n)
-    PriorityQueue<Edge> pq = new PriorityQueue<>(edges);
+    PriorityQueue<CostComparingEdge> pq = new PriorityQueue<>(edges);
     UnionFind uf = new UnionFind(n);
 
     int index = 0;
-    mst = new Edge[n - 1];
+    mst = new CostComparingEdge[n - 1];
 
     while (!pq.isEmpty()) {
       // Use heap to poll the next cheapest edge. Polling avoids the need to sort
       // the edges before loop in the event that the algorithm terminates early.
-      Edge edge = pq.poll();
+      CostComparingEdge edge = pq.poll();
 
       // Skip this edge to avoid creating a cycle in MST.
-      if (uf.connected(edge.u, edge.v)) continue;
+      if (uf.connected(edge.getFrom(), edge.getTo())) continue;
 
       // Include this edge
-      uf.union(edge.u, edge.v);
-      mstCost += edge.cost;
+      uf.union(edge.getFrom(), edge.getTo());
+      mstCost += edge.getCost();
       mst[index++] = edge;
 
       // Stop early if we found a MST that includes all the nodes.
@@ -146,26 +129,26 @@ public class KruskalsEdgeListPartialSortSolver {
 
   public static void main(String[] args) {
     int numNodes = 10;
-    List<Edge> edges = new ArrayList<>();
+    List<CostComparingEdge> edges = new ArrayList<>();
 
-    edges.add(new Edge(0, 1, 5));
-    edges.add(new Edge(1, 2, 4));
-    edges.add(new Edge(2, 9, 2));
-    edges.add(new Edge(0, 4, 1));
-    edges.add(new Edge(0, 3, 4));
-    edges.add(new Edge(1, 3, 2));
-    edges.add(new Edge(2, 7, 4));
-    edges.add(new Edge(2, 8, 1));
-    edges.add(new Edge(9, 8, 0));
-    edges.add(new Edge(4, 5, 1));
-    edges.add(new Edge(5, 6, 7));
-    edges.add(new Edge(6, 8, 4));
-    edges.add(new Edge(4, 3, 2));
-    edges.add(new Edge(5, 3, 5));
-    edges.add(new Edge(3, 6, 11));
-    edges.add(new Edge(6, 7, 1));
-    edges.add(new Edge(3, 7, 2));
-    edges.add(new Edge(7, 8, 6));
+    edges.add(new CostComparingEdge(0, 1, 5));
+    edges.add(new CostComparingEdge(1, 2, 4));
+    edges.add(new CostComparingEdge(2, 9, 2));
+    edges.add(new CostComparingEdge(0, 4, 1));
+    edges.add(new CostComparingEdge(0, 3, 4));
+    edges.add(new CostComparingEdge(1, 3, 2));
+    edges.add(new CostComparingEdge(2, 7, 4));
+    edges.add(new CostComparingEdge(2, 8, 1));
+    edges.add(new CostComparingEdge(9, 8, 0));
+    edges.add(new CostComparingEdge(4, 5, 1));
+    edges.add(new CostComparingEdge(5, 6, 7));
+    edges.add(new CostComparingEdge(6, 8, 4));
+    edges.add(new CostComparingEdge(4, 3, 2));
+    edges.add(new CostComparingEdge(5, 3, 5));
+    edges.add(new CostComparingEdge(3, 6, 11));
+    edges.add(new CostComparingEdge(6, 7, 1));
+    edges.add(new CostComparingEdge(3, 7, 2));
+    edges.add(new CostComparingEdge(7, 8, 6));
 
     KruskalsEdgeListPartialSortSolver solver;
     solver = new KruskalsEdgeListPartialSortSolver(edges, numNodes);
@@ -175,8 +158,9 @@ public class KruskalsEdgeListPartialSortSolver {
       System.out.println("No MST does not exists");
     } else {
       System.out.println("MST cost: " + cost);
-      for (Edge e : solver.getMst()) {
-        System.out.println(String.format("Used edge (%d, %d) with cost: %d", e.u, e.v, e.cost));
+      for (CostComparingEdge e : solver.getMst()) {
+        System.out.println(
+            String.format("Used edge (%d, %d) with cost: %d", e.getFrom(), e.getTo(), e.getCost()));
       }
     }
 

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/LazyPrimsAdjacencyList.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/LazyPrimsAdjacencyList.java
@@ -12,36 +12,21 @@ import java.util.*;
 
 public class LazyPrimsAdjacencyList {
 
-  static class Edge implements Comparable<Edge> {
-    int from, to, cost;
-
-    public Edge(int from, int to, int cost) {
-      this.from = from;
-      this.to = to;
-      this.cost = cost;
-    }
-
-    @Override
-    public int compareTo(Edge other) {
-      return cost - other.cost;
-    }
-  }
-
   // Inputs
   private final int n;
-  private final List<List<Edge>> graph;
+  private final List<List<CostComparingEdge>> graph;
 
   // Internal
   private boolean solved;
   private boolean mstExists;
   private boolean[] visited;
-  private PriorityQueue<Edge> pq;
+  private PriorityQueue<CostComparingEdge> pq;
 
   // Outputs
   private long minCostSum;
-  private Edge[] mstEdges;
+  private CostComparingEdge[] mstEdges;
 
-  public LazyPrimsAdjacencyList(List<List<Edge>> graph) {
+  public LazyPrimsAdjacencyList(List<List<CostComparingEdge>> graph) {
     if (graph == null || graph.isEmpty()) throw new IllegalArgumentException();
     this.n = graph.size();
     this.graph = graph;
@@ -49,7 +34,7 @@ public class LazyPrimsAdjacencyList {
 
   // Returns the edges used in finding the minimum spanning tree,
   // or returns null if no MST exists.
-  public Edge[] getMst() {
+  public CostComparingEdge[] getMst() {
     solve();
     return mstExists ? mstEdges : null;
   }
@@ -63,9 +48,9 @@ public class LazyPrimsAdjacencyList {
     visited[nodeIndex] = true;
 
     // edges will never be null if the createEmptyGraph method was used to build the graph.
-    List<Edge> edges = graph.get(nodeIndex);
-    for (Edge e : edges)
-      if (!visited[e.to]) {
+    List<CostComparingEdge> edges = graph.get(nodeIndex);
+    for (CostComparingEdge e : edges)
+      if (!visited[e.getTo()]) {
         // System.out.printf("(%d, %d, %d)\n", e.from, e.to, e.cost);
         pq.offer(e);
       }
@@ -79,21 +64,21 @@ public class LazyPrimsAdjacencyList {
     int m = n - 1, edgeCount = 0;
     pq = new PriorityQueue<>();
     visited = new boolean[n];
-    mstEdges = new Edge[m];
+    mstEdges = new CostComparingEdge[m];
 
     // Add initial set of edges to the priority queue starting at node 0.
     addEdges(0);
 
     // Loop while the MST is not complete.
     while (!pq.isEmpty() && edgeCount != m) {
-      Edge edge = pq.poll();
-      int nodeIndex = edge.to;
+      CostComparingEdge edge = pq.poll();
+      int nodeIndex = edge.getTo();
 
       // Skip any edge pointing to an already visited node.
       if (visited[nodeIndex]) continue;
 
       mstEdges[edgeCount++] = edge;
-      minCostSum += edge.cost;
+      minCostSum += edge.getCost();
 
       addEdges(nodeIndex);
     }
@@ -104,17 +89,17 @@ public class LazyPrimsAdjacencyList {
 
   /* Graph construction helpers. */
 
-  static List<List<Edge>> createEmptyGraph(int n) {
-    List<List<Edge>> g = new ArrayList<>();
+  static List<List<CostComparingEdge>> createEmptyGraph(int n) {
+    List<List<CostComparingEdge>> g = new ArrayList<>();
     for (int i = 0; i < n; i++) g.add(new ArrayList<>());
     return g;
   }
 
-  static void addDirectedEdge(List<List<Edge>> g, int from, int to, int cost) {
-    g.get(from).add(new Edge(from, to, cost));
+  static void addDirectedEdge(List<List<CostComparingEdge>> g, int from, int to, int cost) {
+    g.get(from).add(new CostComparingEdge(from, to, cost));
   }
 
-  static void addUndirectedEdge(List<List<Edge>> g, int from, int to, int cost) {
+  static void addUndirectedEdge(List<List<CostComparingEdge>> g, int from, int to, int cost) {
     addDirectedEdge(g, from, to, cost);
     addDirectedEdge(g, to, from, cost);
   }
@@ -130,7 +115,7 @@ public class LazyPrimsAdjacencyList {
 
   private static void example1() {
     int n = 10;
-    List<List<Edge>> g = createEmptyGraph(n);
+    List<List<CostComparingEdge>> g = createEmptyGraph(n);
 
     addUndirectedEdge(g, 0, 1, 5);
     addUndirectedEdge(g, 1, 2, 4);
@@ -158,8 +143,9 @@ public class LazyPrimsAdjacencyList {
       System.out.println("No MST does not exists");
     } else {
       System.out.println("MST cost: " + cost);
-      for (Edge e : solver.getMst()) {
-        System.out.println(String.format("from: %d, to: %d, cost: %d", e.from, e.to, e.cost));
+      for (CostComparingEdge e : solver.getMst()) {
+        System.out.println(
+            String.format("from: %d, to: %d, cost: %d", e.getFrom(), e.getTo(), e.getCost()));
       }
     }
 
@@ -178,7 +164,7 @@ public class LazyPrimsAdjacencyList {
 
   private static void firstGraphFromSlides() {
     int n = 7;
-    List<List<Edge>> g = createEmptyGraph(n);
+    List<List<CostComparingEdge>> g = createEmptyGraph(n);
 
     addUndirectedEdge(g, 0, 1, 9);
     addUndirectedEdge(g, 0, 2, 0);
@@ -200,15 +186,16 @@ public class LazyPrimsAdjacencyList {
       System.out.println("No MST does not exists");
     } else {
       System.out.println("MST cost: " + cost);
-      for (Edge e : solver.getMst()) {
-        System.out.println(String.format("from: %d, to: %d, cost: %d", e.from, e.to, e.cost));
+      for (CostComparingEdge e : solver.getMst()) {
+        System.out.println(
+            String.format("from: %d, to: %d, cost: %d", e.getFrom(), e.getTo(), e.getCost()));
       }
     }
   }
 
   private static void squareGraphFromSlides() {
     int n = 9;
-    List<List<Edge>> g = createEmptyGraph(n);
+    List<List<CostComparingEdge>> g = createEmptyGraph(n);
 
     addUndirectedEdge(g, 0, 1, 6);
     addUndirectedEdge(g, 0, 3, 3);
@@ -230,15 +217,16 @@ public class LazyPrimsAdjacencyList {
       System.out.println("No MST does not exists");
     } else {
       System.out.println("MST cost: " + cost);
-      for (Edge e : solver.getMst()) {
-        System.out.println(String.format("from: %d, to: %d, cost: %d", e.from, e.to, e.cost));
+      for (CostComparingEdge e : solver.getMst()) {
+        System.out.println(
+            String.format("from: %d, to: %d, cost: %d", e.getFrom(), e.getTo(), e.getCost()));
       }
     }
   }
 
   private static void lazyPrimsDemoFromSlides() {
     int n = 8;
-    List<List<Edge>> g = createEmptyGraph(n);
+    List<List<CostComparingEdge>> g = createEmptyGraph(n);
 
     addDirectedEdge(g, 0, 1, 10);
     addDirectedEdge(g, 0, 2, 1);
@@ -283,8 +271,9 @@ public class LazyPrimsAdjacencyList {
       System.out.println("No MST does not exists");
     } else {
       System.out.println("MST cost: " + cost);
-      for (Edge e : solver.getMst()) {
-        System.out.println(String.format("from: %d, to: %d, cost: %d", e.from, e.to, e.cost));
+      for (CostComparingEdge e : solver.getMst()) {
+        System.out.println(
+            String.format("from: %d, to: %d, cost: %d", e.getFrom(), e.getTo(), e.getCost()));
       }
     }
   }

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/TopologicalSortAdjacencyList.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/TopologicalSortAdjacencyList.java
@@ -15,30 +15,24 @@ import java.util.*;
 
 public class TopologicalSortAdjacencyList {
 
-  // Helper Edge class to describe edges in the graph
-  static class Edge {
-    int from, to, weight;
-
-    public Edge(int f, int t, int w) {
-      from = f;
-      to = t;
-      weight = w;
-    }
-  }
-
   // Helper method that performs a depth first search on the graph to give
   // us the topological ordering we want. Instead of maintaining a stack
   // of the nodes we see we simply place them inside the ordering array
   // in reverse order for simplicity.
   private static int dfs(
-      int i, int at, boolean[] visited, int[] ordering, Map<Integer, List<Edge>> graph) {
+      int i,
+      int at,
+      boolean[] visited,
+      int[] ordering,
+      Map<Integer, List<WeightedEdge<Integer>>> graph) {
 
     visited[at] = true;
 
-    List<Edge> edges = graph.get(at);
+    List<WeightedEdge<Integer>> edges = graph.get(at);
 
     if (edges != null)
-      for (Edge edge : edges) if (!visited[edge.to]) i = dfs(i, edge.to, visited, ordering, graph);
+      for (WeightedEdge<Integer> edge : edges)
+        if (!visited[edge.getTo()]) i = dfs(i, edge.getTo(), visited, ordering, graph);
 
     ordering[i] = at;
     return i - 1;
@@ -52,7 +46,8 @@ public class TopologicalSortAdjacencyList {
   // in the adjacency list since you can have singleton nodes with no edges which
   // wouldn't be present in the adjacency list but are still part of the graph!
   //
-  public static int[] topologicalSort(Map<Integer, List<Edge>> graph, int numNodes) {
+  public static int[] topologicalSort(
+      Map<Integer, List<WeightedEdge<Integer>>> graph, int numNodes) {
 
     int[] ordering = new int[numNodes];
     boolean[] visited = new boolean[numNodes];
@@ -72,7 +67,8 @@ public class TopologicalSortAdjacencyList {
   // in the adjacency list since you can have singleton nodes with no edges which
   // wouldn't be present in the adjacency list but are still part of the graph!
   //
-  public static Integer[] dagShortestPath(Map<Integer, List<Edge>> graph, int start, int numNodes) {
+  public static Integer[] dagShortestPath(
+      Map<Integer, List<WeightedEdge<Integer>>> graph, int start, int numNodes) {
 
     int[] topsort = topologicalSort(graph, numNodes);
     Integer[] dist = new Integer[numNodes];
@@ -82,13 +78,13 @@ public class TopologicalSortAdjacencyList {
 
       int nodeIndex = topsort[i];
       if (dist[nodeIndex] != null) {
-        List<Edge> adjacentEdges = graph.get(nodeIndex);
+        List<WeightedEdge<Integer>> adjacentEdges = graph.get(nodeIndex);
         if (adjacentEdges != null) {
-          for (Edge edge : adjacentEdges) {
+          for (WeightedEdge<Integer> edge : adjacentEdges) {
 
-            int newDist = dist[nodeIndex] + edge.weight;
-            if (dist[edge.to] == null) dist[edge.to] = newDist;
-            else dist[edge.to] = Math.min(dist[edge.to], newDist);
+            int newDist = dist[nodeIndex] + edge.getCost();
+            if (dist[edge.getTo()] == null) dist[edge.getTo()] = newDist;
+            else dist[edge.getTo()] = Math.min(dist[edge.getTo()], newDist);
           }
         }
       }
@@ -102,17 +98,17 @@ public class TopologicalSortAdjacencyList {
 
     // Graph setup
     final int N = 7;
-    Map<Integer, List<Edge>> graph = new HashMap<>();
+    Map<Integer, List<WeightedEdge<Integer>>> graph = new HashMap<>();
     for (int i = 0; i < N; i++) graph.put(i, new ArrayList<>());
-    graph.get(0).add(new Edge(0, 1, 3));
-    graph.get(0).add(new Edge(0, 2, 2));
-    graph.get(0).add(new Edge(0, 5, 3));
-    graph.get(1).add(new Edge(1, 3, 1));
-    graph.get(1).add(new Edge(1, 2, 6));
-    graph.get(2).add(new Edge(2, 3, 1));
-    graph.get(2).add(new Edge(2, 4, 10));
-    graph.get(3).add(new Edge(3, 4, 5));
-    graph.get(5).add(new Edge(5, 4, 7));
+    graph.get(0).add(new WeightedEdge<>(0, 1, 3));
+    graph.get(0).add(new WeightedEdge<>(0, 2, 2));
+    graph.get(0).add(new WeightedEdge<>(0, 5, 3));
+    graph.get(1).add(new WeightedEdge<>(1, 3, 1));
+    graph.get(1).add(new WeightedEdge<>(1, 2, 6));
+    graph.get(2).add(new WeightedEdge<>(2, 3, 1));
+    graph.get(2).add(new WeightedEdge<>(2, 4, 10));
+    graph.get(3).add(new WeightedEdge<>(3, 4, 5));
+    graph.get(5).add(new WeightedEdge<>(5, 4, 7));
 
     int[] ordering = topologicalSort(graph, N);
 

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/WeightedEdge.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/WeightedEdge.java
@@ -1,0 +1,85 @@
+package com.williamfiset.algorithms.graphtheory;
+
+import java.util.Objects;
+import java.util.function.Predicate;
+
+/**
+ * A generic representation of a weighted edge of a graph.
+ *
+ * @author Sung Ho Yoon
+ */
+public class WeightedEdge<T extends Number> extends Edge {
+  /** The weight (cost) associated with this edge */
+  private T cost;
+
+  private Predicate<T> costCondition;
+
+  /**
+   * Constructs a new weighted edge.
+   *
+   * @param from the source node
+   * @param to the destination node
+   * @param cost the cost associated with the edge
+   */
+  public WeightedEdge(int from, int to, T cost) {
+    super(from, to);
+    this.costCondition = (c) -> true;
+    this.cost = Objects.requireNonNull(cost);
+  }
+
+  /**
+   * Constructs a new weighted edge.
+   *
+   * @param from the source node
+   * @param to the destination node
+   * @param cost the cost associated with the edge
+   * @param costCondition the condition that the cost must satisfy
+   * @throws IllegalArgumentException if the specified cost does not satisfy the provided condition
+   * @throws NullPointerException if any argument is {@code null}
+   */
+  public WeightedEdge(int from, int to, T cost, Predicate<T> costCondition) {
+    super(from, to);
+    this.costCondition = Objects.requireNonNull(costCondition);
+    setCost(cost);
+  }
+
+  /**
+   * Returns the weight (cost) associated with this edge.
+   *
+   * @return the weight (cost) associated with this edge
+   */
+  public final T getCost() {
+    return cost;
+  }
+
+  /**
+   * Sets the weight (cost) associated with this edge.
+   *
+   * @param cost the new weight (cost)
+   * @throws IllegalArgumentException if the specified cost does not satisfy the provided condition
+   *     (if one was provided)
+   * @throws NullPointerException if argument is {@code null}
+   */
+  public void setCost(T cost) {
+    if (!this.costCondition.test(Objects.requireNonNull(cost))) {
+      throw new IllegalArgumentException("Invalid cost: " + cost);
+    }
+    this.cost = cost;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) return true;
+    else if (super.equals(obj) && obj instanceof WeightedEdge) {
+      WeightedEdge<?> edge = (WeightedEdge<?>) obj;
+      return Objects.equals(this.cost, edge.cost);
+    } else return false;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public int hashCode() {
+    return Objects.hash(getFrom(), getTo(), cost);
+  }
+}

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/analysis/PrimsGraphRepresentationAnaylsis.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/analysis/PrimsGraphRepresentationAnaylsis.java
@@ -95,6 +95,7 @@ package com.williamfiset.algorithms.graphtheory.analysis;
 
 import static java.lang.Math.*;
 
+import com.williamfiset.algorithms.graphtheory.CostComparingEdge;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
@@ -102,38 +103,23 @@ import java.util.concurrent.TimeUnit;
 
 public class PrimsGraphRepresentationAnaylsis {
 
-  private static class Edge implements Comparable<Edge> {
-    int from, to, cost;
-
-    public Edge(int from, int to, int cost) {
-      this.from = from;
-      this.to = to;
-      this.cost = cost;
-    }
-
-    @Override
-    public int compareTo(Edge other) {
-      return cost - other.cost;
-    }
-  }
-
   private static class PrimsAdjList {
 
     // Inputs
     private final int n;
-    private final List<List<Edge>> graph;
+    private final List<List<CostComparingEdge>> graph;
 
     // Internal
     private boolean solved;
     private boolean mstExists;
     private boolean[] visited;
-    private MinIndexedDHeap<Edge> ipq;
+    private MinIndexedDHeap<CostComparingEdge> ipq;
 
     // Outputs
     private long minCostSum;
-    private Edge[] mstEdges;
+    private CostComparingEdge[] mstEdges;
 
-    public PrimsAdjList(List<List<Edge>> graph) {
+    public PrimsAdjList(List<List<CostComparingEdge>> graph) {
       if (graph == null || graph.isEmpty()) throw new IllegalArgumentException();
       this.n = graph.size();
       this.graph = graph;
@@ -141,7 +127,7 @@ public class PrimsGraphRepresentationAnaylsis {
 
     // Returns the edges used in finding the minimum spanning tree,
     // or returns null if no MST exists.
-    public Edge[] getMst() {
+    public CostComparingEdge[] getMst() {
       solve();
       return mstExists ? mstEdges : null;
     }
@@ -155,10 +141,10 @@ public class PrimsGraphRepresentationAnaylsis {
       visited[currentNodeIndex] = true;
 
       // edges will never be null if the createEmptyGraph method was used to build the graph.
-      List<Edge> edges = graph.get(currentNodeIndex);
+      List<CostComparingEdge> edges = graph.get(currentNodeIndex);
 
-      for (Edge edge : edges) {
-        int destNodeIndex = edge.to;
+      for (CostComparingEdge edge : edges) {
+        int destNodeIndex = edge.getTo();
 
         // Skip edges pointing to already visited nodes.
         if (visited[destNodeIndex]) continue;
@@ -180,7 +166,7 @@ public class PrimsGraphRepresentationAnaylsis {
 
       int m = n - 1, edgeCount = 0;
       visited = new boolean[n];
-      mstEdges = new Edge[m];
+      mstEdges = new CostComparingEdge[m];
 
       // The degree of the d-ary heap supporting the IPQ can greatly impact performance, especially
       // on dense graphs. The base 2 logarithm of n is a decent value based on my quick experiments
@@ -193,10 +179,10 @@ public class PrimsGraphRepresentationAnaylsis {
 
       while (!ipq.isEmpty() && edgeCount != m) {
         int destNodeIndex = ipq.peekMinKeyIndex(); // equivalently: edge.to
-        Edge edge = ipq.pollMinValue();
+        CostComparingEdge edge = ipq.pollMinValue();
 
         mstEdges[edgeCount++] = edge;
-        minCostSum += edge.cost;
+        minCostSum += edge.getCost();
 
         relaxEdgesAtNode(destNodeIndex);
       }
@@ -208,17 +194,17 @@ public class PrimsGraphRepresentationAnaylsis {
     /* Graph construction helpers. */
 
     // Creates an empty adjacency list graph with n nodes.
-    static List<List<Edge>> createEmptyGraph(int n) {
-      List<List<Edge>> g = new ArrayList<>();
+    static List<List<CostComparingEdge>> createEmptyGraph(int n) {
+      List<List<CostComparingEdge>> g = new ArrayList<>();
       for (int i = 0; i < n; i++) g.add(new ArrayList<>());
       return g;
     }
 
-    static void addDirectedEdge(List<List<Edge>> g, int from, int to, int cost) {
-      g.get(from).add(new Edge(from, to, cost));
+    static void addDirectedEdge(List<List<CostComparingEdge>> g, int from, int to, int cost) {
+      g.get(from).add(new CostComparingEdge(from, to, cost));
     }
 
-    static void addUndirectedEdge(List<List<Edge>> g, int from, int to, int cost) {
+    static void addUndirectedEdge(List<List<CostComparingEdge>> g, int from, int to, int cost) {
       addDirectedEdge(g, from, to, cost);
       addDirectedEdge(g, to, from, cost);
     }
@@ -238,7 +224,7 @@ public class PrimsGraphRepresentationAnaylsis {
 
     // Outputs
     private long minCostSum;
-    private Edge[] mstEdges;
+    private CostComparingEdge[] mstEdges;
 
     public PrimsAdjMatrix(Integer[][] graph) {
       if (graph == null || graph.length == 0 || graph[0].length != graph.length)
@@ -249,7 +235,7 @@ public class PrimsGraphRepresentationAnaylsis {
 
     // Returns the edges used in finding the minimum spanning tree,
     // or returns null if no MST exists.
-    public Edge[] getMst() {
+    public CostComparingEdge[] getMst() {
       // Unimplemented.
       return null;
     }
@@ -345,7 +331,7 @@ public class PrimsGraphRepresentationAnaylsis {
       TimeUnit.SECONDS.sleep(2);
 
       int n = 5000;
-      List<List<Edge>> g1 = PrimsAdjList.createEmptyGraph(n);
+      List<List<CostComparingEdge>> g1 = PrimsAdjList.createEmptyGraph(n);
       Integer[][] g2 = PrimsAdjMatrix.createEmptyGraph(n);
 
       int numEdgesIncluded = 0;

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/examples/EagerPrimsExample.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/examples/EagerPrimsExample.java
@@ -20,6 +20,7 @@ package com.williamfiset.algorithms.graphtheory.examples;
 
 import static java.lang.Math.*;
 
+import com.williamfiset.algorithms.graphtheory.CostComparingEdge;
 import java.util.*;
 
 public class EagerPrimsExample {
@@ -28,7 +29,7 @@ public class EagerPrimsExample {
 
   public static void main(String[] args) {
     int n = 7;
-    List<List<Edge>> g = createEmptyGraph(n);
+    List<List<CostComparingEdge>> g = createEmptyGraph(n);
 
     addUndirectedEdge(g, 0, 1, 9);
     addUndirectedEdge(g, 0, 2, 0);
@@ -50,8 +51,8 @@ public class EagerPrimsExample {
     } else {
       System.out.println("MST cost: " + solver.getMstCost());
       System.out.println("MST edges:");
-      for (Edge e : solver.getMst()) {
-        System.out.println(String.format("  (%d, %d, %d)", e.from, e.to, e.cost));
+      for (CostComparingEdge e : solver.getMst()) {
+        System.out.println(String.format("  (%d, %d, %d)", e.getFrom(), e.getTo(), e.getCost()));
       }
     }
     // MST cost: 9
@@ -67,35 +68,20 @@ public class EagerPrimsExample {
   /* Graph construction helpers. */
 
   // Creates an empty adjacency list graph with n nodes.
-  private static List<List<Edge>> createEmptyGraph(int n) {
-    List<List<Edge>> g = new ArrayList<>();
+  private static List<List<CostComparingEdge>> createEmptyGraph(int n) {
+    List<List<CostComparingEdge>> g = new ArrayList<>();
     for (int i = 0; i < n; i++) g.add(new ArrayList<>());
     return g;
   }
 
-  private static void addDirectedEdge(List<List<Edge>> g, int from, int to, int cost) {
-    g.get(from).add(new Edge(from, to, cost));
+  private static void addDirectedEdge(List<List<CostComparingEdge>> g, int from, int to, int cost) {
+    g.get(from).add(new CostComparingEdge(from, to, cost));
   }
 
-  private static void addUndirectedEdge(List<List<Edge>> g, int from, int to, int cost) {
+  private static void addUndirectedEdge(
+      List<List<CostComparingEdge>> g, int from, int to, int cost) {
     addDirectedEdge(g, from, to, cost);
     addDirectedEdge(g, to, from, cost);
-  }
-
-  // Directed Edge class.
-  private static class Edge implements Comparable<Edge> {
-    int from, to, cost;
-
-    public Edge(int from, int to, int cost) {
-      this.from = from;
-      this.to = to;
-      this.cost = cost;
-    }
-
-    @Override
-    public int compareTo(Edge other) {
-      return cost - other.cost;
-    }
   }
 
   // Solves the MST problem using Prim's algorithm.
@@ -103,19 +89,19 @@ public class EagerPrimsExample {
 
     // Inputs
     private final int n;
-    private final List<List<Edge>> graph;
+    private final List<List<CostComparingEdge>> graph;
 
     // Internal
     private boolean solved;
     private boolean mstExists;
     private boolean[] visited;
-    private MinIndexedDHeap<Edge> ipq;
+    private MinIndexedDHeap<CostComparingEdge> ipq;
 
     // Outputs
     private long minCostSum;
-    private Edge[] mstEdges;
+    private CostComparingEdge[] mstEdges;
 
-    public MinimumSpanningTreeSolver(List<List<Edge>> graph) {
+    public MinimumSpanningTreeSolver(List<List<CostComparingEdge>> graph) {
       if (graph == null || graph.isEmpty()) throw new IllegalArgumentException();
       this.n = graph.size();
       this.graph = graph;
@@ -123,7 +109,7 @@ public class EagerPrimsExample {
 
     // Returns the edges used in finding the minimum spanning tree,
     // or returns null if no MST exists.
-    public Edge[] getMst() {
+    public CostComparingEdge[] getMst() {
       solve();
       return mstExists ? mstEdges : null;
     }
@@ -145,7 +131,7 @@ public class EagerPrimsExample {
 
       int m = n - 1, edgeCount = 0;
       visited = new boolean[n];
-      mstEdges = new Edge[m];
+      mstEdges = new CostComparingEdge[m];
 
       // The degree of the d-ary heap supporting the IPQ can greatly impact performance, especially
       // on dense graphs. The base 2 logarithm of n is a decent value based on my quick experiments
@@ -158,10 +144,10 @@ public class EagerPrimsExample {
 
       while (!ipq.isEmpty() && edgeCount != m) {
         int destNodeIndex = ipq.peekMinKeyIndex(); // equivalently: edge.to
-        Edge edge = ipq.pollMinValue();
+        CostComparingEdge edge = ipq.pollMinValue();
 
         mstEdges[edgeCount++] = edge;
-        minCostSum += edge.cost;
+        minCostSum += edge.getCost();
 
         relaxEdgesAtNode(destNodeIndex);
       }
@@ -174,10 +160,10 @@ public class EagerPrimsExample {
       visited[currentNodeIndex] = true;
 
       // edges will never be null if the createEmptyGraph method was used to build the graph.
-      List<Edge> edges = graph.get(currentNodeIndex);
+      List<CostComparingEdge> edges = graph.get(currentNodeIndex);
 
-      for (Edge edge : edges) {
-        int destNodeIndex = edge.to;
+      for (CostComparingEdge edge : edges) {
+        int destNodeIndex = edge.getTo();
 
         // Skip edges pointing to already visited nodes.
         if (visited[destNodeIndex]) continue;

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/networkflow/CapacityScalingSolverAdjacencyList.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/networkflow/CapacityScalingSolverAdjacencyList.java
@@ -69,14 +69,14 @@ public class CapacityScalingSolverAdjacencyList extends NetworkFlowSolverBase {
     // At sink node, return augmented path flow.
     if (node == t) return flow;
 
-    List<Edge> edges = graph[node];
+    List<NetworkEdge> edges = graph[node];
     visit(node);
 
-    for (Edge edge : edges) {
+    for (NetworkEdge edge : edges) {
       long cap = edge.remainingCapacity();
-      if (cap >= delta && !visited(edge.to)) {
+      if (cap >= delta && !visited(edge.getTo())) {
 
-        long bottleNeck = dfs(edge.to, min(flow, cap));
+        long bottleNeck = dfs(edge.getTo(), min(flow, cap));
 
         // Augment flow with bottle neck value
         if (bottleNeck > 0) {

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/networkflow/Dinics.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/networkflow/Dinics.java
@@ -59,11 +59,11 @@ public class Dinics extends NetworkFlowSolverBase {
     q.offer(s);
     while (!q.isEmpty()) {
       int node = q.poll();
-      for (Edge edge : graph[node]) {
+      for (NetworkEdge edge : graph[node]) {
         long cap = edge.remainingCapacity();
-        if (cap > 0 && level[edge.to] == -1) {
-          level[edge.to] = level[node] + 1;
-          q.offer(edge.to);
+        if (cap > 0 && level[edge.getTo()] == -1) {
+          level[edge.getTo()] = level[node] + 1;
+          q.offer(edge.getTo());
         }
       }
     }
@@ -75,11 +75,11 @@ public class Dinics extends NetworkFlowSolverBase {
     final int numEdges = graph[at].size();
 
     for (; next[at] < numEdges; next[at]++) {
-      Edge edge = graph[at].get(next[at]);
+      NetworkEdge edge = graph[at].get(next[at]);
       long cap = edge.remainingCapacity();
-      if (cap > 0 && level[edge.to] == level[at] + 1) {
+      if (cap > 0 && level[edge.getTo()] == level[at] + 1) {
 
-        long bottleNeck = dfs(edge.to, next, min(flow, cap));
+        long bottleNeck = dfs(edge.getTo(), next, min(flow, cap));
         if (bottleNeck > 0) {
           edge.augment(bottleNeck);
           return bottleNeck;

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/networkflow/EdmondsKarpAdjacencyList.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/networkflow/EdmondsKarpAdjacencyList.java
@@ -41,7 +41,7 @@ public class EdmondsKarpAdjacencyList extends NetworkFlowSolverBase {
   }
 
   private long bfs() {
-    Edge[] prev = new Edge[n];
+    NetworkEdge[] prev = new NetworkEdge[n];
 
     // The queue can be optimized to use a faster queue
     Queue<Integer> q = new ArrayDeque<>(n);
@@ -53,12 +53,12 @@ public class EdmondsKarpAdjacencyList extends NetworkFlowSolverBase {
       int node = q.poll();
       if (node == t) break;
 
-      for (Edge edge : graph[node]) {
+      for (NetworkEdge edge : graph[node]) {
         long cap = edge.remainingCapacity();
-        if (cap > 0 && !visited(edge.to)) {
-          visit(edge.to);
-          prev[edge.to] = edge;
-          q.offer(edge.to);
+        if (cap > 0 && !visited(edge.getTo())) {
+          visit(edge.getTo());
+          prev[edge.getTo()] = edge;
+          q.offer(edge.getTo());
         }
       }
     }
@@ -69,11 +69,12 @@ public class EdmondsKarpAdjacencyList extends NetworkFlowSolverBase {
     long bottleNeck = Long.MAX_VALUE;
 
     // Find augmented path and bottle neck
-    for (Edge edge = prev[t]; edge != null; edge = prev[edge.from])
+    for (NetworkEdge edge = prev[t]; edge != null; edge = prev[edge.getFrom()])
       bottleNeck = min(bottleNeck, edge.remainingCapacity());
 
     // Retrace augmented path and update flow values.
-    for (Edge edge = prev[t]; edge != null; edge = prev[edge.from]) edge.augment(bottleNeck);
+    for (NetworkEdge edge = prev[t]; edge != null; edge = prev[edge.getFrom()])
+      edge.augment(bottleNeck);
 
     // Return bottleneck flow
     return bottleNeck;

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/networkflow/FordFulkersonDfsSolverAdjacencyList.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/networkflow/FordFulkersonDfsSolverAdjacencyList.java
@@ -46,13 +46,13 @@ public class FordFulkersonDfsSolverAdjacencyList extends NetworkFlowSolverBase {
     // At sink node, return augmented path flow.
     if (node == t) return flow;
 
-    List<Edge> edges = graph[node];
+    List<NetworkEdge> edges = graph[node];
     visit(node);
 
-    for (Edge edge : edges) {
+    for (NetworkEdge edge : edges) {
       long rcap = edge.remainingCapacity();
-      if (rcap > 0 && !visited(edge.to)) {
-        long bottleNeck = dfs(edge.to, min(flow, rcap));
+      if (rcap > 0 && !visited(edge.getTo())) {
+        long bottleNeck = dfs(edge.getTo(), min(flow, rcap));
 
         // Augment flow with bottle neck value
         if (bottleNeck > 0) {
@@ -107,11 +107,12 @@ public class FordFulkersonDfsSolverAdjacencyList extends NetworkFlowSolverBase {
 
     System.out.println(solver.getMaxFlow());
 
-    List<Edge>[] g = solver.getGraph();
-    for (List<Edge> edges : g) {
-      for (Edge e : edges) {
-        if (e.to == s || e.from == t) continue;
-        if (e.from == s || e.to == t || e.from < e.to) System.out.println(e.toString(s, t));
+    List<NetworkEdge>[] g = solver.getGraph();
+    for (List<NetworkEdge> edges : g) {
+      for (NetworkEdge e : edges) {
+        if (e.getTo() == s || e.getFrom() == t) continue;
+        if (e.getFrom() == s || e.getTo() == t || e.getFrom() < e.getTo())
+          System.out.println(e.toString(s, t));
         // System.out.println(e.residual.toString(s, t));
       }
     }
@@ -136,9 +137,9 @@ public class FordFulkersonDfsSolverAdjacencyList extends NetworkFlowSolverBase {
 
     System.out.println(solver.getMaxFlow());
 
-    List<Edge>[] g = solver.getGraph();
-    for (List<Edge> edges : g) {
-      for (Edge e : edges) {
+    List<NetworkEdge>[] g = solver.getGraph();
+    for (List<NetworkEdge> edges : g) {
+      for (NetworkEdge e : edges) {
         System.out.println(e.toString(s, t));
         // System.out.println(e.residual.toString(s, t));
       }

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/networkflow/MinCostMaxFlowWithBellmanFord.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/networkflow/MinCostMaxFlowWithBellmanFord.java
@@ -32,15 +32,15 @@ public class MinCostMaxFlowWithBellmanFord extends NetworkFlowSolverBase {
   public void solve() {
 
     // Sum up the bottlenecks on each augmenting path to find the max flow and min cost.
-    List<Edge> path;
+    List<NetworkEdge> path;
     while ((path = getAugmentingPath()).size() != 0) {
 
       // Find bottle neck edge value along path.
       long bottleNeck = Long.MAX_VALUE;
-      for (Edge edge : path) bottleNeck = min(bottleNeck, edge.remainingCapacity());
+      for (NetworkEdge edge : path) bottleNeck = min(bottleNeck, edge.remainingCapacity());
 
       // Retrace path while augmenting the flow
-      for (Edge edge : path) {
+      for (NetworkEdge edge : path) {
         edge.augment(bottleNeck);
         minCost += bottleNeck * edge.originalCost;
       }
@@ -54,28 +54,28 @@ public class MinCostMaxFlowWithBellmanFord extends NetworkFlowSolverBase {
    * Use the Bellman-Ford algorithm (which work with negative edge weights) to find an augmenting
    * path through the flow network.
    */
-  private List<Edge> getAugmentingPath() {
+  private List<NetworkEdge> getAugmentingPath() {
     long[] dist = new long[n];
     Arrays.fill(dist, INF);
     dist[s] = 0;
 
-    Edge[] prev = new Edge[n];
+    NetworkEdge[] prev = new NetworkEdge[n];
 
     // For each vertex, relax all the edges in the graph, O(VE)
     for (int i = 0; i < n - 1; i++) {
       for (int from = 0; from < n; from++) {
-        for (Edge edge : graph[from]) {
-          if (edge.remainingCapacity() > 0 && dist[from] + edge.cost < dist[edge.to]) {
-            dist[edge.to] = dist[from] + edge.cost;
-            prev[edge.to] = edge;
+        for (NetworkEdge edge : graph[from]) {
+          if (edge.remainingCapacity() > 0 && dist[from] + edge.getCost() < dist[edge.getTo()]) {
+            dist[edge.getTo()] = dist[from] + edge.getCost();
+            prev[edge.getTo()] = edge;
           }
         }
       }
     }
 
     // Retrace augmenting path from sink back to the source.
-    LinkedList<Edge> path = new LinkedList<>();
-    for (Edge edge = prev[t]; edge != null; edge = prev[edge.from]) path.addFirst(edge);
+    LinkedList<NetworkEdge> path = new LinkedList<>();
+    for (NetworkEdge edge = prev[t]; edge != null; edge = prev[edge.getFrom()]) path.addFirst(edge);
     return path;
   }
 

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/BreadthFirstSearchAdjacencyListIterativeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/BreadthFirstSearchAdjacencyListIterativeTest.java
@@ -1,7 +1,6 @@
 package com.williamfiset.algorithms.graphtheory;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.williamfiset.algorithms.graphtheory.BreadthFirstSearchAdjacencyListIterative.Edge;
 import static com.williamfiset.algorithms.graphtheory.BreadthFirstSearchAdjacencyListIterative.addUnweightedUndirectedEdge;
 import static com.williamfiset.algorithms.graphtheory.BreadthFirstSearchAdjacencyListIterative.createEmptyGraph;
 import static java.lang.Math.max;
@@ -31,7 +30,7 @@ public class BreadthFirstSearchAdjacencyListIterativeTest {
   @Test
   public void testSingletonGraph() {
     int n = 1;
-    List<List<Edge>> graph = createEmptyGraph(n);
+    List<List<WeightedEdge<Integer>>> graph = createEmptyGraph(n);
 
     solver = new BreadthFirstSearchAdjacencyListIterative(graph);
     List<Integer> path = solver.reconstructPath(0, 0);
@@ -43,7 +42,7 @@ public class BreadthFirstSearchAdjacencyListIterativeTest {
   @Test
   public void testTwoNodeGraph() {
     int n = 2;
-    List<List<Edge>> graph = createEmptyGraph(n);
+    List<List<WeightedEdge<Integer>>> graph = createEmptyGraph(n);
     addUnweightedUndirectedEdge(graph, 0, 1);
     solver = new BreadthFirstSearchAdjacencyListIterative(graph);
 
@@ -58,7 +57,8 @@ public class BreadthFirstSearchAdjacencyListIterativeTest {
   @Test
   public void testThreeNodeGraph() {
     int n = 3;
-    List<List<Edge>> graph = BreadthFirstSearchAdjacencyListIterative.createEmptyGraph(n);
+    List<List<WeightedEdge<Integer>>> graph =
+        BreadthFirstSearchAdjacencyListIterative.createEmptyGraph(n);
     addUnweightedUndirectedEdge(graph, 0, 1);
     addUnweightedUndirectedEdge(graph, 2, 1);
     solver = new BreadthFirstSearchAdjacencyListIterative(graph);
@@ -76,7 +76,7 @@ public class BreadthFirstSearchAdjacencyListIterativeTest {
   public void testShortestPathAgainstBellmanFord() {
     int loops = 150;
     for (int i = 0, n = 1; i < loops; i++, n++) {
-      List<List<Edge>> graph = createEmptyGraph(n);
+      List<List<WeightedEdge<Integer>>> graph = createEmptyGraph(n);
       double[][] graph2 = generateRandomGraph(graph, n);
 
       int s = (int) (random() * n);
@@ -90,7 +90,7 @@ public class BreadthFirstSearchAdjacencyListIterativeTest {
     }
   }
 
-  public static double[][] generateRandomGraph(List<List<Edge>> graph1, int n) {
+  public static double[][] generateRandomGraph(List<List<WeightedEdge<Integer>>> graph1, int n) {
     boolean[][] edgeMatrix = new boolean[n][n];
     double[][] graph2 = new double[n][n];
     for (double[] r : graph2) Arrays.fill(r, Double.POSITIVE_INFINITY);

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/networkflow/MaxFlowTests.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/networkflow/MaxFlowTests.java
@@ -2,7 +2,7 @@ package com.williamfiset.algorithms.graphtheory.networkflow;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.williamfiset.algorithms.graphtheory.networkflow.NetworkFlowSolverBase.Edge;
+import com.williamfiset.algorithms.graphtheory.networkflow.NetworkFlowSolverBase.NetworkEdge;
 import java.util.*;
 import org.junit.jupiter.api.*;
 
@@ -173,14 +173,14 @@ public class MaxFlowTests {
     addEdge(9, t, 60);
 
     for (NetworkFlowSolverBase solver : solvers) {
-      List<Edge>[] g = solver.getGraph();
+      List<NetworkEdge>[] g = solver.getGraph();
       int[] inFlows = new int[n];
       int[] outFlows = new int[n];
       for (int i = 0; i < n; i++) {
-        List<Edge> edges = g[i];
-        for (Edge e : edges) {
-          inFlows[e.from] += e.flow;
-          outFlows[e.to] += e.flow;
+        List<NetworkEdge> edges = g[i];
+        for (NetworkEdge e : edges) {
+          inFlows[e.getFrom()] += e.flow;
+          outFlows[e.getTo()] += e.flow;
         }
       }
 


### PR DESCRIPTION
This PR:
- Removes `com.williamfiset.algorithms.graphtheory.IntStack` (in favor of `com.williamfiset.algorithms.datastructures.stack.IntStack`)
- Refactors various edge implementations defined in several graph algorithm classes  
  Many graph algorithm classes had their own versions of edge implementations that were not compatible with each other. It also introduces a significant amount of code duplication. To resolve these issues, `Edge`, `WeightedEdge`, and `CostComparingEdge` classes are added and the graph algorithm implementations are updated accordingly.