### PR TITLE
Changing Exception Types Being Thrown

### DIFF
--- a/src/main/java/com/williamfiset/algorithms/datastructures/balancedtree/RedBlackTree.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/balancedtree/RedBlackTree.java
@@ -146,7 +146,7 @@ public class RedBlackTree<T extends Comparable<T>> implements Iterable<T> {
 
   public boolean insert(T val) {
     if (val == null) {
-      throw new IllegalArgumentException("Red-Black tree does not allow null values.");
+      throw new NullPointerException("Red-Black tree does not allow null values.");
     }
 
     Node x = root, y = NIL;

--- a/src/main/java/com/williamfiset/algorithms/datastructures/balancedtree/TreapTree.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/balancedtree/TreapTree.java
@@ -93,7 +93,7 @@ public class TreapTree<T extends Comparable<T>> {
 
   public boolean insert(T val, int priority) {
     if (val == null) {
-      throw new IllegalArgumentException("TreapTree does not allow null values");
+      throw new NullPointerException("TreapTree does not allow null values");
     }
     if (!contains(root, val)) {
       root = insert(this.root, val, priority);

--- a/src/main/java/com/williamfiset/algorithms/datastructures/binarysearchtree/SplayTree.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/binarysearchtree/SplayTree.java
@@ -6,6 +6,7 @@ package com.williamfiset.algorithms.datastructures.binarysearchtree;
 
 import com.williamfiset.algorithms.datastructures.utils.TreePrinter;
 import java.util.ArrayList;
+import java.util.Objects;
 import java.util.Scanner;
 
 /**
@@ -30,13 +31,7 @@ public class SplayTree<T extends Comparable<T>> {
     private BinaryTree<T> leftChild, rightChild;
 
     public BinaryTree(T data) {
-      if (data == null) {
-        try {
-          throw new Exception("Null data not allowed into tree");
-        } catch (Exception e) {
-          e.printStackTrace();
-        }
-      } else this.data = data;
+      this.data = Objects.requireNonNull(data);
     }
 
     @Override
@@ -67,13 +62,7 @@ public class SplayTree<T extends Comparable<T>> {
     }
 
     public void setData(T data) {
-      if (data == null) {
-        try {
-          throw new Exception("Null data not allowed into tree");
-        } catch (Exception e) {
-          e.printStackTrace();
-        }
-      } else this.data = data;
+      this.data = Objects.requireNonNull(data);
     }
 
     @Override

--- a/src/main/java/com/williamfiset/algorithms/datastructures/dynamicarray/IntArray.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/dynamicarray/IntArray.java
@@ -22,14 +22,14 @@ public class IntArray implements Iterable<Integer> {
 
   // Initialize the array with a certain capacity
   public IntArray(int capacity) {
-    if (capacity < 0) throw new IllegalArgumentException("Illegal Capacity: " + capacity);
+    if (capacity < 0) throw new NegativeArraySizeException("Illegal Capacity: " + capacity);
     this.capacity = capacity;
     arr = new int[capacity];
   }
 
   // Given an array make it a dynamic array!
   public IntArray(int[] array) {
-    if (array == null) throw new IllegalArgumentException("Array cannot be null");
+    if (array == null) throw new NullPointerException("Array cannot be null");
     arr = java.util.Arrays.copyOf(array, array.length);
     capacity = len = array.length;
   }

--- a/src/main/java/com/williamfiset/algorithms/datastructures/fenwicktree/FenwickTreeRangeQueryPointUpdate.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/fenwicktree/FenwickTreeRangeQueryPointUpdate.java
@@ -23,7 +23,7 @@ public class FenwickTreeRangeQueryPointUpdate {
   // does not get used, O(n) construction.
   public FenwickTreeRangeQueryPointUpdate(long[] values) {
 
-    if (values == null) throw new IllegalArgumentException("Values array cannot be null!");
+    if (values == null) throw new NullPointerException("Values array cannot be null!");
 
     N = values.length;
     values[0] = 0L;

--- a/src/main/java/com/williamfiset/algorithms/datastructures/fenwicktree/FenwickTreeRangeUpdatePointQuery.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/fenwicktree/FenwickTreeRangeUpdatePointQuery.java
@@ -22,7 +22,7 @@ public class FenwickTreeRangeUpdatePointQuery {
   // does not get used, O(n) construction.
   public FenwickTreeRangeUpdatePointQuery(long[] values) {
 
-    if (values == null) throw new IllegalArgumentException("Values array cannot be null!");
+    if (values == null) throw new NullPointerException("Values array cannot be null!");
 
     N = values.length;
     values[0] = 0L;

--- a/src/main/java/com/williamfiset/algorithms/datastructures/fibonacciheap/FibonacciHeap.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/fibonacciheap/FibonacciHeap.java
@@ -71,7 +71,7 @@ public final class FibonacciHeap<E> implements Queue<E> {
 
   public boolean add(E e) {
     if (e == null) {
-      throw new IllegalArgumentException(
+      throw new NullPointerException(
           "Null elements not allowed in this FibonacciHeap implementation.");
     }
 

--- a/src/main/java/com/williamfiset/algorithms/datastructures/hashtable/DoubleHashingTestObject.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/hashtable/DoubleHashingTestObject.java
@@ -6,6 +6,7 @@
  */
 package com.williamfiset.algorithms.datastructures.hashtable;
 
+import java.util.Objects;
 import java.util.Random;
 
 public class DoubleHashingTestObject implements SecondaryHash {
@@ -35,15 +36,13 @@ public class DoubleHashingTestObject implements SecondaryHash {
   }
 
   public DoubleHashingTestObject(int[] data) {
-    if (data == null) throw new IllegalArgumentException("Cannot be null");
-    vectorData = data;
+    vectorData = Objects.requireNonNull(data);
     vectorHash();
     computeHash();
   }
 
   public DoubleHashingTestObject(String data) {
-    if (data == null) throw new IllegalArgumentException("Cannot be null");
-    stringData = data;
+    stringData = Objects.requireNonNull(data);
     stringHash();
     computeHash();
   }

--- a/src/main/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableOpenAddressingBase.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableOpenAddressingBase.java
@@ -172,7 +172,7 @@ public abstract class HashTableOpenAddressingBase<K, V> implements Iterable<K> {
   // Place a key-value pair into the hash-table. If the value already
   // exists inside the hash-table then the value is updated.
   public V insert(K key, V val) {
-    if (key == null) throw new IllegalArgumentException("Null key");
+    if (key == null) throw new NullPointerException("Null key");
     if (usedBuckets >= threshold) resizeTable();
 
     setupProbing(key);
@@ -229,7 +229,7 @@ public abstract class HashTableOpenAddressingBase<K, V> implements Iterable<K> {
 
   // Returns true/false on whether a given key exists within the hash-table
   public boolean hasKey(K key) {
-    if (key == null) throw new IllegalArgumentException("Null key");
+    if (key == null) throw new NullPointerException("Null key");
 
     setupProbing(key);
     final int offset = normalizeIndex(key.hashCode());
@@ -273,7 +273,7 @@ public abstract class HashTableOpenAddressingBase<K, V> implements Iterable<K> {
   // NOTE: returns null if the value is null AND also returns
   // null if the key does not exists.
   public V get(K key) {
-    if (key == null) throw new IllegalArgumentException("Null key");
+    if (key == null) throw new NullPointerException("Null key");
 
     setupProbing(key);
     final int offset = normalizeIndex(key.hashCode());
@@ -319,7 +319,7 @@ public abstract class HashTableOpenAddressingBase<K, V> implements Iterable<K> {
   // NOTE: returns null if the value is null AND also returns
   // null if the key does not exists.
   public V remove(K key) {
-    if (key == null) throw new IllegalArgumentException("Null key");
+    if (key == null) throw new NullPointerException("Null key");
 
     setupProbing(key);
     final int offset = normalizeIndex(key.hashCode());

--- a/src/main/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableSeparateChaining.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableSeparateChaining.java
@@ -104,7 +104,7 @@ public class HashTableSeparateChaining<K, V> implements Iterable<K> {
 
   public V insert(K key, V value) {
 
-    if (key == null) throw new IllegalArgumentException("Null key");
+    if (key == null) throw new NullPointerException("Null key");
     Entry<K, V> newEntry = new Entry<>(key, value);
     int bucketIndex = normalizeIndex(newEntry.hash);
     return bucketInsertEntry(bucketIndex, newEntry);

--- a/src/main/java/com/williamfiset/algorithms/datastructures/kdtree/GeneralKDTree.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/kdtree/GeneralKDTree.java
@@ -185,7 +185,7 @@ public class GeneralKDTree<T extends Comparable<T>> {
     private KDNode<E> right;
 
     public KDNode(E[] coords) {
-      if (coords == null) throw new IllegalArgumentException("Error: Null coordinate set passed");
+      if (coords == null) throw new NullPointerException("Error: Null coordinate set passed");
       if (coords.length != k)
         throw new IllegalArgumentException(
             "Error: Expected " + k + "dimensions, but given " + coords.length);

--- a/src/main/java/com/williamfiset/algorithms/datastructures/linkedlist/DoublyLinkedList.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/linkedlist/DoublyLinkedList.java
@@ -78,9 +78,9 @@ public class DoublyLinkedList<T> implements Iterable<T> {
   }
 
   // Add an element at a specified index
-  public void addAt(int index, T data) throws Exception {
+  public void addAt(int index, T data) {
     if (index < 0 || index > size) {
-      throw new Exception("Illegal Index");
+      throw new IndexOutOfBoundsException(index);
     }
     if (index == 0) {
       addFirst(data);

--- a/src/main/java/com/williamfiset/algorithms/datastructures/linkedlist/DoublyLinkedList.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/linkedlist/DoublyLinkedList.java
@@ -105,20 +105,20 @@ public class DoublyLinkedList<T> implements Iterable<T> {
 
   // Check the value of the first node if it exists, O(1)
   public T peekFirst() {
-    if (isEmpty()) throw new RuntimeException("Empty list");
+    if (isEmpty()) throw new IllegalStateException("Empty list");
     return head.data;
   }
 
   // Check the value of the last node if it exists, O(1)
   public T peekLast() {
-    if (isEmpty()) throw new RuntimeException("Empty list");
+    if (isEmpty()) throw new IllegalStateException("Empty list");
     return tail.data;
   }
 
   // Remove the first value at the head of the linked list, O(1)
   public T removeFirst() {
     // Can't remove data from an empty list
-    if (isEmpty()) throw new RuntimeException("Empty list");
+    if (isEmpty()) throw new IllegalStateException("Empty list");
 
     // Extract the data at the head and move
     // the head pointer forwards one node
@@ -139,7 +139,7 @@ public class DoublyLinkedList<T> implements Iterable<T> {
   // Remove the last value at the tail of the linked list, O(1)
   public T removeLast() {
     // Can't remove data from an empty list
-    if (isEmpty()) throw new RuntimeException("Empty list");
+    if (isEmpty()) throw new IllegalStateException("Empty list");
 
     // Extract the data at the tail and move
     // the tail pointer backwards one node
@@ -185,7 +185,7 @@ public class DoublyLinkedList<T> implements Iterable<T> {
   public T removeAt(int index) {
     // Make sure the index provided is valid
     if (index < 0 || index >= size) {
-      throw new IllegalArgumentException();
+      throw new IndexOutOfBoundsException(index);
     }
 
     int i;

--- a/src/main/java/com/williamfiset/algorithms/datastructures/priorityqueue/BinaryHeap.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/priorityqueue/BinaryHeap.java
@@ -8,6 +8,7 @@ package com.williamfiset.algorithms.datastructures.priorityqueue;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 
 public class BinaryHeap<T extends Comparable<T>> {
 
@@ -90,9 +91,7 @@ public class BinaryHeap<T extends Comparable<T>> {
   // element must not be null, O(log(n))
   public void add(T elem) {
 
-    if (elem == null) throw new IllegalArgumentException();
-
-    heap.add(elem);
+    heap.add(Objects.requireNonNull(elem));
 
     int indexOfLastElem = size() - 1;
     swim(indexOfLastElem);

--- a/src/main/java/com/williamfiset/algorithms/datastructures/priorityqueue/BinaryHeapQuickRemovals.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/priorityqueue/BinaryHeapQuickRemovals.java
@@ -11,6 +11,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -106,9 +107,7 @@ public class BinaryHeapQuickRemovals<T extends Comparable<T>> {
   // element must not be null, O(log(n))
   public void add(T elem) {
 
-    if (elem == null) throw new IllegalArgumentException();
-
-    heap.add(elem);
+    heap.add(Objects.requireNonNull(elem));
     int indexOfLastElem = size() - 1;
     mapAdd(elem, indexOfLastElem);
 

--- a/src/main/java/com/williamfiset/algorithms/datastructures/priorityqueue/MinDHeap.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/priorityqueue/MinDHeap.java
@@ -5,6 +5,8 @@
  */
 package com.williamfiset.algorithms.datastructures.priorityqueue;
 
+import java.util.Objects;
+
 @SuppressWarnings("unchecked")
 public class MinDHeap<T extends Comparable<T>> {
 
@@ -61,8 +63,7 @@ public class MinDHeap<T extends Comparable<T>> {
 
   // Adds a none null element to the priority queue
   public void add(T elem) {
-    if (elem == null) throw new IllegalArgumentException("No null elements please :)");
-    heap[sz] = elem;
+    heap[sz] = Objects.requireNonNull(elem);
     swim(sz);
     sz++;
   }

--- a/src/main/java/com/williamfiset/algorithms/datastructures/priorityqueue/MinIndexedDHeap.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/priorityqueue/MinIndexedDHeap.java
@@ -18,6 +18,7 @@ import static java.lang.Math.min;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 
 public class MinIndexedDHeap<T extends Comparable<T>> {
 
@@ -104,7 +105,7 @@ public class MinIndexedDHeap<T extends Comparable<T>> {
 
   public void insert(int ki, T value) {
     if (contains(ki)) throw new IllegalArgumentException("index already exists; received: " + ki);
-    valueNotNullOrThrow(value);
+    Objects.requireNonNull(value);
     pm[ki] = sz;
     im[sz] = ki;
     values[ki] = value;
@@ -218,20 +219,15 @@ public class MinIndexedDHeap<T extends Comparable<T>> {
 
   private void keyExistsAndValueNotNullOrThrow(int ki, Object value) {
     keyExistsOrThrow(ki);
-    valueNotNullOrThrow(value);
+    Objects.requireNonNull(value);
   }
 
   private void keyExistsOrThrow(int ki) {
     if (!contains(ki)) throw new NoSuchElementException("Index does not exist; received: " + ki);
   }
 
-  private void valueNotNullOrThrow(Object value) {
-    if (value == null) throw new IllegalArgumentException("value cannot be null");
-  }
-
   private void keyInBoundsOrThrow(int ki) {
-    if (ki < 0 || ki >= N)
-      throw new IllegalArgumentException("Key index out of bounds; received: " + ki);
+    if (ki < 0 || ki >= N) throw new IndexOutOfBoundsException(ki);
   }
 
   /* Test functions */

--- a/src/main/java/com/williamfiset/algorithms/datastructures/quadtree/QuadTree.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/quadtree/QuadTree.java
@@ -76,8 +76,7 @@ public class QuadTree {
 
     // Construct a quad tree for a particular region.
     public Node(Rect region) {
-      if (region == null) throw new IllegalArgumentException("Illegal argument");
-      this.region = region;
+      this.region = Objects.requireNonNull(region);
       X = new long[NUM_POINTS];
       Y = new long[NUM_POINTS];
     }

--- a/src/main/java/com/williamfiset/algorithms/datastructures/queue/ArrayQueue.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/queue/ArrayQueue.java
@@ -1,5 +1,7 @@
 package com.williamfiset.algorithms.datastructures.queue;
 
+import java.util.NoSuchElementException;
+
 /**
  * Besides the Generics, the loss of property of size is another difference between ArrayQueue and
  * IntQueue. The size of ArrayQueue is calculated by the formula, as are empty status and full
@@ -27,7 +29,7 @@ public class ArrayQueue<T> implements Queue<T> {
   @Override
   public void offer(T elem) {
     if (isFull()) {
-      throw new RuntimeException("Queue is full");
+      throw new IllegalStateException("Queue is full");
     }
     data[rear++] = elem;
     rear = adjustIndex(rear, data.length);
@@ -37,7 +39,7 @@ public class ArrayQueue<T> implements Queue<T> {
   @SuppressWarnings("unchecked")
   public T poll() {
     if (isEmpty()) {
-      throw new RuntimeException("Queue is empty");
+      throw new NoSuchElementException("Queue is empty");
     }
     front = adjustIndex(front, data.length);
     return (T) data[front++];
@@ -47,7 +49,7 @@ public class ArrayQueue<T> implements Queue<T> {
   @SuppressWarnings("unchecked")
   public T peek() {
     if (isEmpty()) {
-      throw new RuntimeException("Queue is empty");
+      throw new NoSuchElementException("Queue is empty");
     }
     front = adjustIndex(front, data.length);
     return (T) data[front];

--- a/src/main/java/com/williamfiset/algorithms/datastructures/queue/IntQueue.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/queue/IntQueue.java
@@ -9,6 +9,8 @@
  */
 package com.williamfiset.algorithms.datastructures.queue;
 
+import java.util.NoSuchElementException;
+
 public class IntQueue implements Queue<Integer> {
 
   private int[] data;
@@ -35,7 +37,7 @@ public class IntQueue implements Queue<Integer> {
   @Override
   public Integer peek() {
     if (isEmpty()) {
-      throw new RuntimeException("Queue is empty");
+      throw new NoSuchElementException("Queue is empty");
     }
     front = front % data.length;
     return data[front];
@@ -49,7 +51,7 @@ public class IntQueue implements Queue<Integer> {
   @Override
   public void offer(Integer value) {
     if (isFull()) {
-      throw new RuntimeException("Queue too small!");
+      throw new IllegalStateException("Queue too small!");
     }
     data[end++] = value;
     size++;
@@ -60,7 +62,7 @@ public class IntQueue implements Queue<Integer> {
   @Override
   public Integer poll() {
     if (size == 0) {
-      throw new RuntimeException("Queue is empty");
+      throw new NoSuchElementException("Queue is empty");
     }
     size--;
     front = front % data.length;

--- a/src/main/java/com/williamfiset/algorithms/datastructures/queue/LinkedQueue.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/queue/LinkedQueue.java
@@ -5,6 +5,8 @@
  */
 package com.williamfiset.algorithms.datastructures.queue;
 
+import java.util.NoSuchElementException;
+
 public class LinkedQueue<T> implements Iterable<T>, Queue<T> {
 
   private java.util.LinkedList<T> list = new java.util.LinkedList<T>();
@@ -28,14 +30,14 @@ public class LinkedQueue<T> implements Iterable<T>, Queue<T> {
   // Peek the element at the front of the queue
   // The method throws an error is the queue is empty
   public T peek() {
-    if (isEmpty()) throw new RuntimeException("Queue Empty");
+    if (isEmpty()) throw new NoSuchElementException("Queue Empty");
     return list.peekFirst();
   }
 
   // Poll an element from the front of the queue
   // The method throws an error is the queue is empty
   public T poll() {
-    if (isEmpty()) throw new RuntimeException("Queue Empty");
+    if (isEmpty()) throw new NoSuchElementException("Queue Empty");
     return list.removeFirst();
   }
 

--- a/src/main/java/com/williamfiset/algorithms/datastructures/segmenttree/GenericSegmentTree.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/segmenttree/GenericSegmentTree.java
@@ -169,13 +169,13 @@ public class GenericSegmentTree {
       SegmentCombinationFn segmentCombinationFunction,
       RangeUpdateFn rangeUpdateFunction) {
     if (values == null) {
-      throw new IllegalArgumentException("Segment tree values cannot be null.");
+      throw new NullPointerException("Segment tree values cannot be null.");
     }
     if (segmentCombinationFunction == null) {
-      throw new IllegalArgumentException("Please specify a valid segment combination function.");
+      throw new NullPointerException("Please specify a valid segment combination function.");
     }
     if (rangeUpdateFunction == null) {
-      throw new IllegalArgumentException("Please specify a valid range update function.");
+      throw new NullPointerException("Please specify a valid range update function.");
     }
     n = values.length;
 

--- a/src/main/java/com/williamfiset/algorithms/datastructures/segmenttree/GenericSegmentTree2.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/segmenttree/GenericSegmentTree2.java
@@ -197,13 +197,13 @@ public class GenericSegmentTree2 {
       SegmentCombinationFn segmentCombinationFunction,
       RangeUpdateFn rangeUpdateFunction) {
     if (values == null) {
-      throw new IllegalArgumentException("Segment tree values cannot be null.");
+      throw new NullPointerException("Segment tree values cannot be null.");
     }
     if (segmentCombinationFunction == null) {
-      throw new IllegalArgumentException("Please specify a valid segment combination function.");
+      throw new NullPointerException("Please specify a valid segment combination function.");
     }
     if (rangeUpdateFunction == null) {
-      throw new IllegalArgumentException("Please specify a valid range update function.");
+      throw new NullPointerException("Please specify a valid range update function.");
     }
     n = values.length;
 

--- a/src/main/java/com/williamfiset/algorithms/datastructures/segmenttree/GenericSegmentTree3.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/segmenttree/GenericSegmentTree3.java
@@ -251,13 +251,13 @@ public class GenericSegmentTree3 {
   //     SegmentCombinationFn segmentCombinationFunction,
   //     RangeUpdateFn rangeUpdateFunction) {
   //   if (values == null) {
-  //     throw new IllegalArgumentException("Segment tree values cannot be null.");
+  //     throw new NullPointerException("Segment tree values cannot be null.");
   //   }
   //   if (segmentCombinationFunction == null) {
-  //     throw new IllegalArgumentException("Please specify a valid segment combination function.");
+  //     throw new NullPointerException("Please specify a valid segment combination function.");
   //   }
   //   if (rangeUpdateFunction == null) {
-  //     throw new IllegalArgumentException("Please specify a valid range update function.");
+  //     throw new NullPointerException("Please specify a valid range update function.");
   //   }
   //   n = values.length;
 

--- a/src/main/java/com/williamfiset/algorithms/datastructures/segmenttree/MaxQuerySumUpdateSegmentTree.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/segmenttree/MaxQuerySumUpdateSegmentTree.java
@@ -42,7 +42,7 @@ public class MaxQuerySumUpdateSegmentTree {
 
   public MaxQuerySumUpdateSegmentTree(long[] values) {
     if (values == null) {
-      throw new IllegalArgumentException("Segment tree values cannot be null.");
+      throw new NullPointerException("Segment tree values cannot be null.");
     }
     n = values.length;
 

--- a/src/main/java/com/williamfiset/algorithms/datastructures/segmenttree/MinQueryAssignUpdateSegmentTree.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/segmenttree/MinQueryAssignUpdateSegmentTree.java
@@ -32,7 +32,7 @@ public class MinQueryAssignUpdateSegmentTree {
 
   public MinQueryAssignUpdateSegmentTree(long[] values) {
     if (values == null) {
-      throw new IllegalArgumentException("Segment tree values cannot be null.");
+      throw new NullPointerException("Segment tree values cannot be null.");
     }
 
     n = values.length;

--- a/src/main/java/com/williamfiset/algorithms/datastructures/segmenttree/MinQuerySumUpdateSegmentTree.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/segmenttree/MinQuerySumUpdateSegmentTree.java
@@ -43,7 +43,7 @@ public class MinQuerySumUpdateSegmentTree {
 
   public MinQuerySumUpdateSegmentTree(long[] values) {
     if (values == null) {
-      throw new IllegalArgumentException("Segment tree values cannot be null.");
+      throw new NullPointerException("Segment tree values cannot be null.");
     }
     n = values.length;
 

--- a/src/main/java/com/williamfiset/algorithms/datastructures/segmenttree/Node.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/segmenttree/Node.java
@@ -19,7 +19,7 @@ public class Node {
   int minPos, maxPos, min = 0, sum = 0, lazy = 0;
 
   public Node(int[] values) {
-    if (values == null) throw new IllegalArgumentException("Null input to segment tree.");
+    if (values == null) throw new NullPointerException("Null input to segment tree.");
     buildTree(0, values.length);
     for (int i = 0; i < values.length; i++) {
       update(i, i + 1, values[i]);

--- a/src/main/java/com/williamfiset/algorithms/datastructures/segmenttree/RangeQueryPointUpdateSegmentTree.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/segmenttree/RangeQueryPointUpdateSegmentTree.java
@@ -68,13 +68,13 @@ public class RangeQueryPointUpdateSegmentTree {
       SegmentCombinationFn segmentCombinationFunction,
       RangeUpdateFn rangeUpdateFunction) {
     if (values == null) {
-      throw new IllegalArgumentException("Segment tree values cannot be null.");
+      throw new NullPointerException("Segment tree values cannot be null.");
     }
     if (segmentCombinationFunction == null) {
-      throw new IllegalArgumentException("Please specify a valid segment combination function.");
+      throw new NullPointerException("Please specify a valid segment combination function.");
     }
     if (rangeUpdateFunction == null) {
-      throw new IllegalArgumentException("Please specify a valid range update function.");
+      throw new NullPointerException("Please specify a valid range update function.");
     }
     n = values.length;
     this.segmentCombinationFn = segmentCombinationFunction;

--- a/src/main/java/com/williamfiset/algorithms/datastructures/segmenttree/SumQueryAssignUpdateSegmentTree.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/segmenttree/SumQueryAssignUpdateSegmentTree.java
@@ -38,7 +38,7 @@ public class SumQueryAssignUpdateSegmentTree {
 
   public SumQueryAssignUpdateSegmentTree(long[] values) {
     if (values == null) {
-      throw new IllegalArgumentException("Segment tree values cannot be null.");
+      throw new NullPointerException("Segment tree values cannot be null.");
     }
 
     n = values.length;

--- a/src/main/java/com/williamfiset/algorithms/datastructures/segmenttree/SumQueryMultiplicationUpdateSegmentTree.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/segmenttree/SumQueryMultiplicationUpdateSegmentTree.java
@@ -52,7 +52,7 @@ public class SumQueryMultiplicationUpdateSegmentTree {
 
   public SumQueryMultiplicationUpdateSegmentTree(long[] values) {
     if (values == null) {
-      throw new IllegalArgumentException("Segment tree values cannot be null.");
+      throw new NullPointerException("Segment tree values cannot be null.");
     }
     n = values.length;
 

--- a/src/main/java/com/williamfiset/algorithms/datastructures/segmenttree/SumQuerySumUpdateSegmentTree.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/segmenttree/SumQuerySumUpdateSegmentTree.java
@@ -32,7 +32,7 @@ public class SumQuerySumUpdateSegmentTree {
 
   public SumQuerySumUpdateSegmentTree(long[] values) {
     if (values == null) {
-      throw new IllegalArgumentException("Segment tree values cannot be null.");
+      throw new NullPointerException("Segment tree values cannot be null.");
     }
     n = values.length;
 

--- a/src/main/java/com/williamfiset/algorithms/datastructures/stack/ArrayStack.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/stack/ArrayStack.java
@@ -1,7 +1,7 @@
 package com.williamfiset.algorithms.datastructures.stack;
 
 import java.util.Arrays;
-import java.util.EmptyStackException;
+import java.util.NoSuchElementException;
 
 /**
  * @author liujingkun
@@ -43,7 +43,7 @@ public class ArrayStack<T> implements Stack<T> {
   @Override
   @SuppressWarnings("unchecked")
   public T pop() {
-    if (isEmpty()) throw new EmptyStackException();
+    if (isEmpty()) throw new NoSuchElementException();
     T elem = (T) data[--size];
     data[size] = null;
     return elem;
@@ -52,7 +52,7 @@ public class ArrayStack<T> implements Stack<T> {
   @Override
   @SuppressWarnings("unchecked")
   public T peek() {
-    if (isEmpty()) throw new EmptyStackException();
+    if (isEmpty()) throw new NoSuchElementException();
     return (T) data[size - 1];
   }
 }

--- a/src/main/java/com/williamfiset/algorithms/datastructures/stack/ListStack.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/stack/ListStack.java
@@ -5,6 +5,8 @@
  */
 package com.williamfiset.algorithms.datastructures.stack;
 
+import java.util.NoSuchElementException;
+
 public class ListStack<T> implements Iterable<T>, Stack<T> {
 
   private java.util.LinkedList<T> list = new java.util.LinkedList<T>();
@@ -35,14 +37,14 @@ public class ListStack<T> implements Iterable<T>, Stack<T> {
   // Pop an element off the stack
   // Throws an error is the stack is empty
   public T pop() {
-    if (isEmpty()) throw new java.util.EmptyStackException();
+    if (isEmpty()) throw new NoSuchElementException();
     return list.removeLast();
   }
 
   // Peek the top of the stack without removing an element
   // Throws an exception if the stack is empty
   public T peek() {
-    if (isEmpty()) throw new java.util.EmptyStackException();
+    if (isEmpty()) throw new NoSuchElementException();
     return list.peekLast();
   }
 

--- a/src/main/java/com/williamfiset/algorithms/datastructures/suffixarray/SuffixArray.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/suffixarray/SuffixArray.java
@@ -5,6 +5,8 @@
  */
 package com.williamfiset.algorithms.datastructures.suffixarray;
 
+import java.util.Objects;
+
 public abstract class SuffixArray {
 
   // Length of the suffix array
@@ -23,8 +25,7 @@ public abstract class SuffixArray {
   private boolean constructedLcpArray = false;
 
   public SuffixArray(int[] text) {
-    if (text == null) throw new IllegalArgumentException("Text cannot be null.");
-    this.T = text;
+    this.T = Objects.requireNonNull(text);
     this.N = text.length;
   }
 

--- a/src/main/java/com/williamfiset/algorithms/datastructures/trie/Trie.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/trie/Trie.java
@@ -27,7 +27,7 @@ public class Trie {
   // contains a prefix already in the trie
   public boolean insert(String key, int numInserts) {
 
-    if (key == null) throw new IllegalArgumentException("Null not permitted in trie");
+    if (key == null) throw new NullPointerException("Null not permitted in trie");
     if (numInserts <= 0)
       throw new IllegalArgumentException("numInserts has to be greater than zero");
 
@@ -114,7 +114,7 @@ public class Trie {
   // Returns the count of a particular prefix
   public int count(String key) {
 
-    if (key == null) throw new IllegalArgumentException("Null not permitted");
+    if (key == null) throw new NullPointerException("Null not permitted");
 
     Node node = root;
 

--- a/src/main/java/com/williamfiset/algorithms/dp/CoinChange.java
+++ b/src/main/java/com/williamfiset/algorithms/dp/CoinChange.java
@@ -32,7 +32,7 @@ public class CoinChange {
   private static final int INF = Integer.MAX_VALUE / 2;
 
   public static Solution coinChange(int[] coins, final int n) {
-    if (coins == null) throw new IllegalArgumentException("Coins array is null");
+    if (coins == null) throw new NullPointerException("Coins array is null");
     if (coins.length == 0) throw new IllegalArgumentException("No coin values :/");
     for (int coin : coins) {
       if (coin <= 0) {
@@ -86,7 +86,7 @@ public class CoinChange {
   }
 
   public static Solution coinChangeSpaceEfficient(int[] coins, int n) {
-    if (coins == null) throw new IllegalArgumentException("Coins array is null");
+    if (coins == null) throw new NullPointerException("Coins array is null");
 
     // Initialize table and set everything to infinity except first cell
     int[] dp = new int[n + 1];
@@ -135,7 +135,7 @@ public class CoinChange {
   // all possible states like the tabular approach does. This can speedup
   // things especially if the coin denominations are large.
   public static int coinChangeRecursive(int[] coins, int n) {
-    if (coins == null) throw new IllegalArgumentException("Coins array is null");
+    if (coins == null) throw new NullPointerException("Coins array is null");
     if (n < 0) return -1;
 
     int[] dp = new int[n + 1];

--- a/src/main/java/com/williamfiset/algorithms/dp/EditDistanceRecursive.java
+++ b/src/main/java/com/williamfiset/algorithms/dp/EditDistanceRecursive.java
@@ -7,6 +7,8 @@
  */
 package com.williamfiset.algorithms.dp;
 
+import java.util.Objects;
+
 public class EditDistanceRecursive {
 
   final char[] a, b;
@@ -14,11 +16,8 @@ public class EditDistanceRecursive {
 
   public EditDistanceRecursive(
       String a, String b, int insertionCost, int deletionCost, int substitutionCost) {
-    if (a == null || b == null) {
-      throw new IllegalArgumentException("Input string must not be null");
-    }
-    this.a = a.toCharArray();
-    this.b = b.toCharArray();
+    this.a = Objects.requireNonNull(a).toCharArray();
+    this.b = Objects.requireNonNull(b).toCharArray();
     this.insertionCost = insertionCost;
     this.deletionCost = deletionCost;
     this.substitutionCost = substitutionCost;

--- a/src/main/java/com/williamfiset/algorithms/dp/KnapsackUnbounded.java
+++ b/src/main/java/com/williamfiset/algorithms/dp/KnapsackUnbounded.java
@@ -13,6 +13,8 @@
  */
 package com.williamfiset.algorithms.dp;
 
+import java.util.Objects;
+
 public class KnapsackUnbounded {
 
   /**
@@ -24,7 +26,7 @@ public class KnapsackUnbounded {
    */
   public static int unboundedKnapsack(int maxWeight, int[] W, int[] V) {
 
-    if (W == null || V == null || W.length != V.length || maxWeight < 0)
+    if (Objects.requireNonNull(W).length != Objects.requireNonNull(V).length || maxWeight < 0)
       throw new IllegalArgumentException("Invalid input");
 
     final int N = W.length;
@@ -56,7 +58,7 @@ public class KnapsackUnbounded {
 
   public static int unboundedKnapsackSpaceEfficient(int maxWeight, int[] W, int[] V) {
 
-    if (W == null || V == null || W.length != V.length)
+    if (Objects.requireNonNull(W).length != Objects.requireNonNull(V).length)
       throw new IllegalArgumentException("Invalid input");
 
     final int N = W.length;

--- a/src/main/java/com/williamfiset/algorithms/dp/Knapsack_01.java
+++ b/src/main/java/com/williamfiset/algorithms/dp/Knapsack_01.java
@@ -13,6 +13,7 @@ package com.williamfiset.algorithms.dp;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class Knapsack_01 {
 
@@ -25,7 +26,7 @@ public class Knapsack_01 {
    */
   public static int knapsack(int capacity, int[] W, int[] V) {
 
-    if (W == null || V == null || W.length != V.length || capacity < 0)
+    if (Objects.requireNonNull(W).length != Objects.requireNonNull(V).length || capacity < 0)
       throw new IllegalArgumentException("Invalid input");
 
     final int N = W.length;

--- a/src/main/java/com/williamfiset/algorithms/dp/MinimumWeightPerfectMatching.java
+++ b/src/main/java/com/williamfiset/algorithms/dp/MinimumWeightPerfectMatching.java
@@ -32,7 +32,7 @@ public class MinimumWeightPerfectMatching {
 
   // The cost matrix should be a symmetric (i.e cost[i][j] = cost[j][i])
   public MinimumWeightPerfectMatching(double[][] cost) {
-    if (cost == null) throw new IllegalArgumentException("Input cannot be null");
+    this.cost = Objects.requireNonNull(cost);
     n = cost.length;
     if (n == 0) throw new IllegalArgumentException("Matrix size is zero");
     if (n % 2 != 0)
@@ -42,7 +42,6 @@ public class MinimumWeightPerfectMatching {
           "Matrix too large! A matrix that size for the MWPM problem with a time complexity of"
               + "O(n^2*2^n) requires way too much computation and memory for a modern home computer.");
     END_STATE = (1 << n) - 1;
-    this.cost = cost;
   }
 
   public double getMinWeightCost() {

--- a/src/main/java/com/williamfiset/algorithms/dp/WeightedMaximumCardinalityMatchingIterative.java
+++ b/src/main/java/com/williamfiset/algorithms/dp/WeightedMaximumCardinalityMatchingIterative.java
@@ -33,7 +33,7 @@ public class WeightedMaximumCardinalityMatchingIterative implements MwpmInterfac
 
   // The cost matrix should be a symmetric (i.e cost[i][j] = cost[j][i])
   public WeightedMaximumCardinalityMatchingIterative(double[][] cost) {
-    if (cost == null) throw new IllegalArgumentException("Input cannot be null");
+    this.cost = Objects.requireNonNull(cost);
     n = cost.length;
     if (n == 0) throw new IllegalArgumentException("Matrix size is zero");
     if (n % 2 != 0)
@@ -43,7 +43,6 @@ public class WeightedMaximumCardinalityMatchingIterative implements MwpmInterfac
           "Matrix too large! A matrix that size for the MWPM problem with a time complexity of"
               + "O(n^2*2^n) requires way too much computation and memory for a modern home computer.");
     END_STATE = (1 << n) - 1;
-    this.cost = cost;
   }
 
   public double getMinWeightCost() {

--- a/src/main/java/com/williamfiset/algorithms/dp/WeightedMaximumCardinalityMatchingRecursive.java
+++ b/src/main/java/com/williamfiset/algorithms/dp/WeightedMaximumCardinalityMatchingRecursive.java
@@ -87,8 +87,7 @@ public class WeightedMaximumCardinalityMatchingRecursive implements MwpmInterfac
   // The cost matrix should be a symmetric (i.e cost[i][j] = cost[j][i]) and have a cost of `null`
   // between nodes i and j if no edge exists between those two nodes.
   public WeightedMaximumCardinalityMatchingRecursive(Double[][] cost) {
-    if (cost == null) throw new IllegalArgumentException("Input cannot be null");
-    n = cost.length;
+    n = Objects.requireNonNull(cost).length;
     if (n <= 1) throw new IllegalArgumentException("Invalid matrix size: " + n);
     setCostMatrix(cost);
     FULL_STATE = (1 << n) - 1;

--- a/src/main/java/com/williamfiset/algorithms/dp/examples/editdistance/EditDistance.java
+++ b/src/main/java/com/williamfiset/algorithms/dp/examples/editdistance/EditDistance.java
@@ -10,11 +10,8 @@ public class EditDistance {
 
   public EditDistance(
       String a, String b, int insertionCost, int deletionCost, int substitutionCost) {
-    if (a == null || b == null) {
-      throw new IllegalArgumentException("Input string must not be null");
-    }
-    this.a = a.toCharArray();
-    this.b = b.toCharArray();
+    this.a = Objects.requireNonNull(a).toCharArray();
+    this.b = Objects.requireNonNull(b).toCharArray();
     this.insertionCost = insertionCost;
     this.deletionCost = deletionCost;
     this.substitutionCost = substitutionCost;

--- a/src/main/java/com/williamfiset/algorithms/geometry/CollinearPoints.java
+++ b/src/main/java/com/williamfiset/algorithms/geometry/CollinearPoints.java
@@ -11,6 +11,7 @@ package com.williamfiset.algorithms.geometry;
 import static java.lang.Math.*;
 
 import java.awt.geom.Point2D;
+import java.util.Objects;
 
 public class CollinearPoints {
 
@@ -23,6 +24,10 @@ public class CollinearPoints {
   // to the left from the frame of reference of standing at point a
   // and facing point b.
   public static int collinear(Point2D a, Point2D b, Point2D c) {
+
+    Objects.requireNonNull(a);
+    Objects.requireNonNull(b);
+    Objects.requireNonNull(c);
 
     if (a.distance(b) < EPS) throw new IllegalArgumentException("a cannot equal b");
 

--- a/src/main/java/com/williamfiset/algorithms/geometry/ConvexPolygonArea.java
+++ b/src/main/java/com/williamfiset/algorithms/geometry/ConvexPolygonArea.java
@@ -9,6 +9,7 @@
 package com.williamfiset.algorithms.geometry;
 
 import java.awt.geom.Point2D;
+import java.util.Objects;
 
 public class ConvexPolygonArea {
 
@@ -17,7 +18,7 @@ public class ConvexPolygonArea {
   // method is an array of N+1 points where points[0] = points[N]
   public static double convexPolygonArea(Point2D[] points) {
 
-    int N = points.length - 1;
+    int N = Objects.requireNonNull(points).length - 1;
 
     if (N < 3 || points[0] != points[N])
       throw new IllegalArgumentException(

--- a/src/main/java/com/williamfiset/algorithms/geometry/PointInsideTriangle.java
+++ b/src/main/java/com/williamfiset/algorithms/geometry/PointInsideTriangle.java
@@ -11,6 +11,7 @@ package com.williamfiset.algorithms.geometry;
 import static java.lang.Math.*;
 
 import java.awt.geom.Point2D;
+import java.util.Objects;
 
 public class PointInsideTriangle {
 
@@ -60,6 +61,9 @@ public class PointInsideTriangle {
   // to the left from the frame of reference of standing at point a
   // and facing point b.
   private static int collinear(Point2D a, Point2D b, Point2D c) {
+    Objects.requireNonNull(a);
+    Objects.requireNonNull(b);
+    Objects.requireNonNull(c);
     double ax = a.getX(), ay = a.getY();
     double bx = b.getX(), by = b.getY();
     double cx = c.getX(), cy = c.getY();

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/ArticulationPointsAdjacencyList.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/ArticulationPointsAdjacencyList.java
@@ -12,6 +12,7 @@ import static java.lang.Math.min;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class ArticulationPointsAdjacencyList {
 
@@ -22,7 +23,7 @@ public class ArticulationPointsAdjacencyList {
   private List<List<Integer>> graph;
 
   public ArticulationPointsAdjacencyList(List<List<Integer>> graph, int n) {
-    if (graph == null || n <= 0 || graph.size() != n) throw new IllegalArgumentException();
+    if (n <= 0 || Objects.requireNonNull(graph).size() != n) throw new IllegalArgumentException();
     this.graph = graph;
     this.n = n;
   }

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/Boruvkas.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/Boruvkas.java
@@ -44,8 +44,7 @@ public class Boruvkas {
   private List<Edge> mst;
 
   public Boruvkas(int n, int m, Edge[] graph) {
-    if (graph == null) throw new IllegalArgumentException();
-    this.graph = graph;
+    this.graph = Objects.requireNonNull(graph);
     this.n = n;
     this.m = m;
   }

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/BreadthFirstSearchAdjacencyListIterative.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/BreadthFirstSearchAdjacencyListIterative.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
+import java.util.Objects;
 
 public class BreadthFirstSearchAdjacencyListIterative {
 
@@ -30,9 +31,8 @@ public class BreadthFirstSearchAdjacencyListIterative {
   private List<List<Edge>> graph;
 
   public BreadthFirstSearchAdjacencyListIterative(List<List<Edge>> graph) {
-    if (graph == null) throw new IllegalArgumentException("Graph can not be null");
+    this.graph = Objects.requireNonNull(graph);
     n = graph.size();
-    this.graph = graph;
   }
 
   /**

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/BridgesAdjacencyList.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/BridgesAdjacencyList.java
@@ -12,6 +12,7 @@ import static java.lang.Math.min;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class BridgesAdjacencyList {
 
@@ -23,8 +24,8 @@ public class BridgesAdjacencyList {
   private List<Integer> bridges;
 
   public BridgesAdjacencyList(List<List<Integer>> graph, int n) {
-    if (graph == null || n <= 0 || graph.size() != n) throw new IllegalArgumentException();
-    this.graph = graph;
+    this.graph = Objects.requireNonNull(graph);
+    if (n <= 0 || graph.size() != n) throw new IllegalArgumentException();
     this.n = n;
   }
 

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/BridgesAdjacencyListIterative.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/BridgesAdjacencyListIterative.java
@@ -24,8 +24,8 @@ public class BridgesAdjacencyListIterative {
   private static int CALLBACK_TOKEN = -2;
 
   public BridgesAdjacencyListIterative(List<List<Integer>> graph, int n) {
-    if (graph == null || n <= 0 || graph.size() != n) throw new IllegalArgumentException();
-    this.graph = graph;
+    this.graph = Objects.requireNonNull(graph);
+    if (n <= 0 || graph.size() != n) throw new IllegalArgumentException();
     this.n = n;
   }
 

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/ChinesePostmanProblem.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/ChinesePostmanProblem.java
@@ -224,7 +224,7 @@ public class ChinesePostmanProblem {
     // The cost matrix should be a symmetric (i.e cost[i][j] = cost[j][i]) and have a cost of `null`
     // between nodes i and j if no edge exists between those two nodes.
     public WeightedMaximumCardinalityMatchingRecursive(Double[][] cost) {
-      if (cost == null) throw new IllegalArgumentException("Input cannot be null");
+      Objects.requireNonNull(cost);
       n = cost.length;
       if (n <= 1) throw new IllegalArgumentException("Invalid matrix size: " + n);
       setCostMatrix(cost);
@@ -412,9 +412,8 @@ public class ChinesePostmanProblem {
     private List<List<Edge>> graph;
 
     public EulerianPathDirectedEdgesAdjacencyList(List<List<Edge>> graph) {
-      if (graph == null) throw new IllegalArgumentException("Graph cannot be null");
+      this.graph = Objects.requireNonNull(graph);
       n = graph.size();
-      this.graph = graph;
       path = new LinkedList<>();
     }
 

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/ConnectedComponentsDfsSolverAdjacencyList.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/ConnectedComponentsDfsSolverAdjacencyList.java
@@ -23,9 +23,8 @@ public class ConnectedComponentsDfsSolverAdjacencyList {
    * @param graph - An undirected graph as an adjacency list.
    */
   public ConnectedComponentsDfsSolverAdjacencyList(List<List<Integer>> graph) {
-    if (graph == null) throw new NullPointerException();
+    this.graph = Objects.requireNonNull(graph);
     this.n = graph.size();
-    this.graph = graph;
   }
 
   public int[] getComponents() {

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/DijkstrasShortestPathAdjacencyList.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/DijkstrasShortestPathAdjacencyList.java
@@ -14,6 +14,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.PriorityQueue;
 
 public class DijkstrasShortestPathAdjacencyList {
@@ -72,8 +73,7 @@ public class DijkstrasShortestPathAdjacencyList {
 
   public DijkstrasShortestPathAdjacencyList(int n, Comparator<Node> comparator) {
     this(n);
-    if (comparator == null) throw new IllegalArgumentException("Comparator cannot be null");
-    this.comparator = comparator;
+    this.comparator = Objects.requireNonNull(comparator);
   }
 
   /**
@@ -100,8 +100,9 @@ public class DijkstrasShortestPathAdjacencyList {
    *     'end' are not connected then an empty array is returned.
    */
   public List<Integer> reconstructPath(int start, int end) {
-    if (end < 0 || end >= n) throw new IllegalArgumentException("Invalid node index");
-    if (start < 0 || start >= n) throw new IllegalArgumentException("Invalid node index");
+    if (end < 0 || end >= n) throw new IndexOutOfBoundsException("Invalid node index: " + end);
+    if (start < 0 || start >= n)
+      throw new IndexOutOfBoundsException("Invalid node index: " + start);
     double dist = dijkstra(start, end);
     List<Integer> path = new ArrayList<>();
     if (dist == Double.POSITIVE_INFINITY) return path;

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/DijkstrasShortestPathAdjacencyListWithDHeap.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/DijkstrasShortestPathAdjacencyListWithDHeap.java
@@ -15,6 +15,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 
 public class DijkstrasShortestPathAdjacencyListWithDHeap {
 
@@ -138,8 +139,9 @@ public class DijkstrasShortestPathAdjacencyListWithDHeap {
    *     'end' are not connected then an empty array is returned.
    */
   public List<Integer> reconstructPath(int start, int end) {
-    if (end < 0 || end >= n) throw new IllegalArgumentException("Invalid node index");
-    if (start < 0 || start >= n) throw new IllegalArgumentException("Invalid node index");
+    if (end < 0 || end >= n) throw new IndexOutOfBoundsException("Invalid node index: " + end);
+    if (start < 0 || start >= n)
+      throw new IndexOutOfBoundsException("Invalid node index: " + start);
     List<Integer> path = new ArrayList<>();
     double dist = dijkstra(start, end);
     if (dist == Double.POSITIVE_INFINITY) return path;
@@ -233,7 +235,7 @@ public class DijkstrasShortestPathAdjacencyListWithDHeap {
 
     public void insert(int ki, T value) {
       if (contains(ki)) throw new IllegalArgumentException("index already exists; received: " + ki);
-      valueNotNullOrThrow(value);
+      Objects.requireNonNull(value);
       pm[ki] = sz;
       im[sz] = ki;
       values[ki] = value;
@@ -347,20 +349,15 @@ public class DijkstrasShortestPathAdjacencyListWithDHeap {
 
     private void keyExistsAndValueNotNullOrThrow(int ki, Object value) {
       keyExistsOrThrow(ki);
-      valueNotNullOrThrow(value);
+      Objects.requireNonNull(value);
     }
 
     private void keyExistsOrThrow(int ki) {
       if (!contains(ki)) throw new NoSuchElementException("Index does not exist; received: " + ki);
     }
 
-    private void valueNotNullOrThrow(Object value) {
-      if (value == null) throw new IllegalArgumentException("value cannot be null");
-    }
-
     private void keyInBoundsOrThrow(int ki) {
-      if (ki < 0 || ki >= N)
-        throw new IllegalArgumentException("Key index out of bounds; received: " + ki);
+      if (ki < 0 || ki >= N) throw new IndexOutOfBoundsException(ki);
     }
   }
 }

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/EagerPrimsAdjacencyList.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/EagerPrimsAdjacencyList.java
@@ -44,9 +44,8 @@ public class EagerPrimsAdjacencyList {
   private Edge[] mstEdges;
 
   public EagerPrimsAdjacencyList(List<List<Edge>> graph) {
-    if (graph == null || graph.isEmpty()) throw new IllegalArgumentException();
+    this.graph = Objects.requireNonNull(graph);
     this.n = graph.size();
-    this.graph = graph;
   }
 
   // Returns the edges used in finding the minimum spanning tree,
@@ -470,7 +469,7 @@ public class EagerPrimsAdjacencyList {
 
     public void insert(int ki, T value) {
       if (contains(ki)) throw new IllegalArgumentException("index already exists; received: " + ki);
-      valueNotNullOrThrow(value);
+      Objects.requireNonNull(value);
       pm[ki] = sz;
       im[sz] = ki;
       values[ki] = value;
@@ -584,20 +583,15 @@ public class EagerPrimsAdjacencyList {
 
     private void keyExistsAndValueNotNullOrThrow(int ki, Object value) {
       keyExistsOrThrow(ki);
-      valueNotNullOrThrow(value);
+      Objects.requireNonNull(value);
     }
 
     private void keyExistsOrThrow(int ki) {
       if (!contains(ki)) throw new NoSuchElementException("Index does not exist; received: " + ki);
     }
 
-    private void valueNotNullOrThrow(Object value) {
-      if (value == null) throw new IllegalArgumentException("value cannot be null");
-    }
-
     private void keyInBoundsOrThrow(int ki) {
-      if (ki < 0 || ki >= N)
-        throw new IllegalArgumentException("Key index out of bounds; received: " + ki);
+      if (ki < 0 || ki >= N) throw new IndexOutOfBoundsException(ki);
     }
 
     /* Test functions */

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/EulerianPathDirectedEdgesAdjacencyList.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/EulerianPathDirectedEdgesAdjacencyList.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 
 public class EulerianPathDirectedEdgesAdjacencyList {
 
@@ -27,9 +28,8 @@ public class EulerianPathDirectedEdgesAdjacencyList {
   private List<List<Integer>> graph;
 
   public EulerianPathDirectedEdgesAdjacencyList(List<List<Integer>> graph) {
-    if (graph == null) throw new IllegalArgumentException("Graph cannot be null");
+    this.graph = Objects.requireNonNull(graph);
     n = graph.size();
-    this.graph = graph;
     path = new LinkedList<>();
   }
 

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/Kosaraju.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/Kosaraju.java
@@ -29,8 +29,7 @@ public class Kosaraju {
   private List<List<Integer>> transposeGraph;
 
   public Kosaraju(List<List<Integer>> graph) {
-    if (graph == null) throw new IllegalArgumentException("Graph cannot be null.");
-    this.graph = graph;
+    this.graph = Objects.requireNonNull(graph);
     n = graph.size();
   }
 

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/KruskalsEdgeListPartialSortSolver.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/KruskalsEdgeListPartialSortSolver.java
@@ -11,6 +11,7 @@ package com.williamfiset.algorithms.graphtheory;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.PriorityQueue;
 
 public class KruskalsEdgeListPartialSortSolver {
@@ -47,8 +48,8 @@ public class KruskalsEdgeListPartialSortSolver {
   // edges - A list of undirected edges.
   // n     - The number of nodes in the input graph.
   public KruskalsEdgeListPartialSortSolver(List<Edge> edges, int n) {
-    if (edges == null || n <= 1) throw new IllegalArgumentException();
-    this.edges = edges;
+    this.edges = Objects.requireNonNull(edges);
+    if (n <= 1) throw new IllegalArgumentException();
     this.n = n;
   }
 

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/LazyPrimsAdjacencyList.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/LazyPrimsAdjacencyList.java
@@ -42,9 +42,9 @@ public class LazyPrimsAdjacencyList {
   private Edge[] mstEdges;
 
   public LazyPrimsAdjacencyList(List<List<Edge>> graph) {
-    if (graph == null || graph.isEmpty()) throw new IllegalArgumentException();
+    this.graph = Objects.requireNonNull(graph);
+    if (graph.isEmpty()) throw new IllegalArgumentException();
     this.n = graph.size();
-    this.graph = graph;
   }
 
   // Returns the edges used in finding the minimum spanning tree,

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/TarjanSccSolverAdjacencyList.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/TarjanSccSolverAdjacencyList.java
@@ -33,9 +33,8 @@ public class TarjanSccSolverAdjacencyList {
   private static final int UNVISITED = -1;
 
   public TarjanSccSolverAdjacencyList(List<List<Integer>> graph) {
-    if (graph == null) throw new IllegalArgumentException("Graph cannot be null.");
+    this.graph = Objects.requireNonNull(graph);
     n = graph.size();
-    this.graph = graph;
   }
 
   // Returns the number of strongly connected components in the graph.

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/TspDynamicProgrammingIterative.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/TspDynamicProgrammingIterative.java
@@ -11,6 +11,7 @@ package com.williamfiset.algorithms.graphtheory;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 public class TspDynamicProgrammingIterative {
 
@@ -25,10 +26,13 @@ public class TspDynamicProgrammingIterative {
   }
 
   public TspDynamicProgrammingIterative(int start, double[][] distance) {
+
+    Objects.requireNonNull(distance);
     N = distance.length;
 
     if (N <= 2) throw new IllegalStateException("N <= 2 not yet supported.");
-    if (N != distance[0].length) throw new IllegalStateException("Matrix must be square (n x n)");
+    if (N != distance[0].length)
+      throw new IllegalArgumentException("Matrix must be square (n x n)");
     if (start < 0 || start >= N) throw new IllegalArgumentException("Invalid start node.");
     if (N > 32)
       throw new IllegalArgumentException(

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/TspDynamicProgrammingRecursive.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/TspDynamicProgrammingRecursive.java
@@ -33,7 +33,7 @@ public class TspDynamicProgrammingRecursive {
 
   public TspDynamicProgrammingRecursive(int startNode, double[][] distance) {
 
-    this.distance = distance;
+    this.distance = Objects.requireNonNull(distance);
     N = distance.length;
     START_NODE = startNode;
 

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/analysis/PrimsGraphRepresentationAnaylsis.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/analysis/PrimsGraphRepresentationAnaylsis.java
@@ -134,9 +134,9 @@ public class PrimsGraphRepresentationAnaylsis {
     private Edge[] mstEdges;
 
     public PrimsAdjList(List<List<Edge>> graph) {
-      if (graph == null || graph.isEmpty()) throw new IllegalArgumentException();
+      this.graph = Objects.requireNonNull(graph);
+      if (graph.isEmpty()) throw new IllegalArgumentException();
       this.n = graph.size();
-      this.graph = graph;
     }
 
     // Returns the edges used in finding the minimum spanning tree,
@@ -241,10 +241,10 @@ public class PrimsGraphRepresentationAnaylsis {
     private Edge[] mstEdges;
 
     public PrimsAdjMatrix(Integer[][] graph) {
-      if (graph == null || graph.length == 0 || graph[0].length != graph.length)
+      this.graph = Objects.requireNonNull(graph);
+      if (graph.length == 0 || graph[0].length != graph.length)
         throw new IllegalArgumentException();
       this.n = graph.length;
-      this.graph = graph;
     }
 
     // Returns the edges used in finding the minimum spanning tree,
@@ -473,7 +473,7 @@ public class PrimsGraphRepresentationAnaylsis {
 
     public void insert(int ki, T value) {
       if (contains(ki)) throw new IllegalArgumentException("index already exists; received: " + ki);
-      valueNotNullOrThrow(value);
+      Objects.requireNonNull(value);
       pm[ki] = sz;
       im[sz] = ki;
       values[ki] = value;
@@ -587,20 +587,15 @@ public class PrimsGraphRepresentationAnaylsis {
 
     private void keyExistsAndValueNotNullOrThrow(int ki, Object value) {
       keyExistsOrThrow(ki);
-      valueNotNullOrThrow(value);
+      Objects.requireNonNull(value);
     }
 
     private void keyExistsOrThrow(int ki) {
       if (!contains(ki)) throw new NoSuchElementException("Index does not exist; received: " + ki);
     }
 
-    private void valueNotNullOrThrow(Object value) {
-      if (value == null) throw new IllegalArgumentException("value cannot be null");
-    }
-
     private void keyInBoundsOrThrow(int ki) {
-      if (ki < 0 || ki >= N)
-        throw new IllegalArgumentException("Key index out of bounds; received: " + ki);
+      if (ki < 0 || ki >= N) throw new IndexOutOfBoundsException(ki);
     }
 
     /* Test functions */

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/examples/EagerPrimsExample.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/examples/EagerPrimsExample.java
@@ -116,9 +116,9 @@ public class EagerPrimsExample {
     private Edge[] mstEdges;
 
     public MinimumSpanningTreeSolver(List<List<Edge>> graph) {
-      if (graph == null || graph.isEmpty()) throw new IllegalArgumentException();
+      this.graph = Objects.requireNonNull(graph);
+      if (graph.isEmpty()) throw new IllegalArgumentException();
       this.n = graph.size();
-      this.graph = graph;
     }
 
     // Returns the edges used in finding the minimum spanning tree,
@@ -280,7 +280,7 @@ public class EagerPrimsExample {
 
     public void insert(int ki, T value) {
       if (contains(ki)) throw new IllegalArgumentException("index already exists; received: " + ki);
-      valueNotNullOrThrow(value);
+      Objects.requireNonNull(value);
       pm[ki] = sz;
       im[sz] = ki;
       values[ki] = value;
@@ -394,20 +394,15 @@ public class EagerPrimsExample {
 
     private void keyExistsAndValueNotNullOrThrow(int ki, Object value) {
       keyExistsOrThrow(ki);
-      valueNotNullOrThrow(value);
+      Objects.requireNonNull(value);
     }
 
     private void keyExistsOrThrow(int ki) {
       if (!contains(ki)) throw new NoSuchElementException("Index does not exist; received: " + ki);
     }
 
-    private void valueNotNullOrThrow(Object value) {
-      if (value == null) throw new IllegalArgumentException("value cannot be null");
-    }
-
     private void keyInBoundsOrThrow(int ki) {
-      if (ki < 0 || ki >= N)
-        throw new IllegalArgumentException("Key index out of bounds; received: " + ki);
+      if (ki < 0 || ki >= N) throw new IndexOutOfBoundsException(ki);
     }
 
     /* Test functions */

--- a/src/main/java/com/williamfiset/algorithms/graphtheory/networkflow/BipartiteGraphCheckAdjacencyList.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/networkflow/BipartiteGraphCheckAdjacencyList.java
@@ -10,6 +10,7 @@ package com.williamfiset.algorithms.graphtheory.networkflow;
 
 import com.williamfiset.algorithms.utils.graphutils.Utils;
 import java.util.List;
+import java.util.Objects;
 
 public class BipartiteGraphCheckAdjacencyList {
 
@@ -22,9 +23,8 @@ public class BipartiteGraphCheckAdjacencyList {
   public static final int RED = 0b10, BLACK = (RED ^ 1);
 
   public BipartiteGraphCheckAdjacencyList(List<List<Integer>> graph) {
-    if (graph == null) throw new IllegalArgumentException("Graph cannot be null.");
+    this.graph = Objects.requireNonNull(graph);
     n = graph.size();
-    this.graph = graph;
   }
 
   // Checks whether the input graph is bipartite.

--- a/src/main/java/com/williamfiset/algorithms/other/SlidingWindowMaximum.java
+++ b/src/main/java/com/williamfiset/algorithms/other/SlidingWindowMaximum.java
@@ -10,6 +10,7 @@ package com.williamfiset.algorithms.other;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.Objects;
 
 public class SlidingWindowMaximum {
 
@@ -19,8 +20,7 @@ public class SlidingWindowMaximum {
   Deque<Integer> deque = new ArrayDeque<>();
 
   public SlidingWindowMaximum(int[] values) {
-    if (values == null) throw new IllegalArgumentException();
-    this.values = values;
+    this.values = Objects.requireNonNull(values);
     N = values.length;
   }
 

--- a/src/main/java/com/williamfiset/algorithms/strings/LongestCommonSubstring.java
+++ b/src/main/java/com/williamfiset/algorithms/strings/LongestCommonSubstring.java
@@ -64,8 +64,7 @@ public class LongestCommonSubstring {
     private boolean constructedLcpArray = false;
 
     public SuffixArray(int[] text) {
-      if (text == null) throw new IllegalArgumentException("Text cannot be null.");
-      this.T = text;
+      this.T = Objects.requireNonNull(text);
       this.N = text.length;
     }
 
@@ -315,7 +314,7 @@ public class LongestCommonSubstring {
 
     // TODO(williamfiset): support LCS with strings as int arrays for larger alphabet sizes.
     public LcsSolver(String[] strings) {
-      if (strings == null || strings.length <= 1)
+      if (Objects.requireNonNull(strings).length <= 1)
         throw new IllegalArgumentException("Invalid strings array provided.");
       this.strings = strings;
     }
@@ -503,8 +502,7 @@ public class LongestCommonSubstring {
     Deque<Integer> deque = new ArrayDeque<>();
 
     public SlidingWindowMinimum(int[] values) {
-      if (values == null) throw new IllegalArgumentException();
-      this.values = values;
+      this.values = Objects.requireNonNull(values);
       N = values.length;
     }
 

--- a/src/main/java/com/williamfiset/algorithms/utils/graphutils/Utils.java
+++ b/src/main/java/com/williamfiset/algorithms/utils/graphutils/Utils.java
@@ -7,6 +7,7 @@ package com.williamfiset.algorithms.utils.graphutils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public final class Utils {
 
@@ -24,12 +25,12 @@ public final class Utils {
 
   /** Adds an unweighted directed edge from the node at index 'from' to the node at index 'to'. */
   public static void addDirectedEdge(List<List<Integer>> graph, int from, int to) {
-    if (graph == null) throw new IllegalArgumentException("graph cannot be null");
+    Objects.requireNonNull(graph);
     int n = graph.size();
     if (from < 0 || from >= n)
-      throw new IllegalArgumentException("'from' node index out of bounds; received: " + from);
+      throw new IndexOutOfBoundsException("'from' node index out of bounds; received: " + from);
     if (to < 0 || to >= n)
-      throw new IllegalArgumentException("'to' node index out of bounds; received: " + to);
+      throw new IndexOutOfBoundsException("'to' node index out of bounds; received: " + to);
     graph.get(from).add(to);
   }
 

--- a/src/test/java/com/williamfiset/algorithms/datastructures/balancedtree/RedBlackTreeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/balancedtree/RedBlackTreeTest.java
@@ -22,7 +22,7 @@ public class RedBlackTreeTest {
 
   @Test
   public void testNullInsertion() {
-    assertThrows(IllegalArgumentException.class, () -> tree.insert(null));
+    assertThrows(NullPointerException.class, () -> tree.insert(null));
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/balancedtree/TreapTreeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/balancedtree/TreapTreeTest.java
@@ -25,7 +25,7 @@ public class TreapTreeTest {
 
   @Test
   public void testNullInsertion() {
-    assertThrows(IllegalArgumentException.class, () -> tree.insert(null));
+    assertThrows(NullPointerException.class, () -> tree.insert(null));
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/fenwicktree/FenwickTreeRangeQueryPointUpdateTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/fenwicktree/FenwickTreeRangeQueryPointUpdateTest.java
@@ -171,7 +171,7 @@ public class FenwickTreeRangeQueryPointUpdateTest {
 
   @Test
   public void testIllegalCreation() {
-    assertThrows(IllegalArgumentException.class, () -> new FenwickTreeRangeQueryPointUpdate(null));
+    assertThrows(NullPointerException.class, () -> new FenwickTreeRangeQueryPointUpdate(null));
   }
 
   // Generate a list of random numbers, one based

--- a/src/test/java/com/williamfiset/algorithms/datastructures/fenwicktree/FenwickTreeRangeUpdatePointQueryTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/fenwicktree/FenwickTreeRangeUpdatePointQueryTest.java
@@ -38,7 +38,7 @@ public class FenwickTreeRangeUpdatePointQueryTest {
 
   @Test
   public void testIllegalCreation() {
-    assertThrows(IllegalArgumentException.class, () -> new FenwickTreeRangeUpdatePointQuery(null));
+    assertThrows(NullPointerException.class, () -> new FenwickTreeRangeUpdatePointQuery(null));
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableLinearProbingTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableLinearProbingTest.java
@@ -48,7 +48,7 @@ public class HashTableLinearProbingTest {
 
   @Test
   public void testNullKey() {
-    assertThrows(IllegalArgumentException.class, () -> map.put(null, 5));
+    assertThrows(NullPointerException.class, () -> map.put(null, 5));
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableQuadraticProbingTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableQuadraticProbingTest.java
@@ -48,7 +48,7 @@ public class HashTableQuadraticProbingTest {
 
   @Test
   public void testNullKey() {
-    assertThrows(IllegalArgumentException.class, () -> map.put(null, 5));
+    assertThrows(NullPointerException.class, () -> map.put(null, 5));
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/kdtree/GeneralKDTreeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/kdtree/GeneralKDTreeTest.java
@@ -36,7 +36,7 @@ public class GeneralKDTreeTest {
   @Test
   public void testInsertNull() {
     GeneralKDTree<Integer> kdTree = new GeneralKDTree<Integer>(2);
-    assertThrows(IllegalArgumentException.class, () -> kdTree.insert(null));
+    assertThrows(NullPointerException.class, () -> kdTree.insert(null));
   }
 
   @Test
@@ -68,7 +68,7 @@ public class GeneralKDTreeTest {
   @Test
   public void testSearchNull() {
     GeneralKDTree<Integer> kdTree = new GeneralKDTree<Integer>(2);
-    assertThrows(IllegalArgumentException.class, () -> kdTree.search(null));
+    assertThrows(NullPointerException.class, () -> kdTree.search(null));
   }
 
   @Test
@@ -176,7 +176,7 @@ public class GeneralKDTreeTest {
   @Test
   public void testDeleteNull() {
     GeneralKDTree<Integer> kdTree = new GeneralKDTree<Integer>(2);
-    assertThrows(IllegalArgumentException.class, () -> kdTree.delete(null));
+    assertThrows(NullPointerException.class, () -> kdTree.delete(null));
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/datastructures/segmenttree/SegmentTreeWithPointersTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/segmenttree/SegmentTreeWithPointersTest.java
@@ -16,7 +16,7 @@ public class SegmentTreeWithPointersTest {
   @Test
   public void testIllegalSegmentTreeCreation1() {
     assertThrows(
-        IllegalArgumentException.class,
+        NullPointerException.class,
         () -> {
           Node tree = new Node(null);
         });

--- a/src/test/java/com/williamfiset/algorithms/datastructures/trie/TrieTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/trie/TrieTest.java
@@ -45,7 +45,7 @@ public class TrieTest {
   @Test
   public void testBadTrieInsert() {
     assertThrows(
-        IllegalArgumentException.class,
+        NullPointerException.class,
         () -> {
           (new Trie()).insert(null);
         });
@@ -54,7 +54,7 @@ public class TrieTest {
   @Test
   public void testBadTrieCount() {
     assertThrows(
-        IllegalArgumentException.class,
+        NullPointerException.class,
         () -> {
           (new Trie()).count(null);
         });
@@ -63,7 +63,7 @@ public class TrieTest {
   @Test
   public void testBadTrieContains() {
     assertThrows(
-        IllegalArgumentException.class,
+        NullPointerException.class,
         () -> {
           (new Trie()).contains(null);
         });

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/BreadthFirstSearchAdjacencyListIterativeTest.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/BreadthFirstSearchAdjacencyListIterativeTest.java
@@ -25,7 +25,7 @@ public class BreadthFirstSearchAdjacencyListIterativeTest {
   @Test
   public void testNullGraphInput() {
     assertThrows(
-        IllegalArgumentException.class, () -> new BreadthFirstSearchAdjacencyListIterative(null));
+        NullPointerException.class, () -> new BreadthFirstSearchAdjacencyListIterative(null));
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/KosarajuTest.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/KosarajuTest.java
@@ -28,7 +28,7 @@ public class KosarajuTest {
 
   @Test
   public void nullGraphConstructor() {
-    assertThrowsExactly(IllegalArgumentException.class, () -> new Kosaraju(null));
+    assertThrowsExactly(NullPointerException.class, () -> new Kosaraju(null));
   }
 
   @Test

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/TarjanSccSolverAdjacencyListTest.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/TarjanSccSolverAdjacencyListTest.java
@@ -23,7 +23,7 @@ public class TarjanSccSolverAdjacencyListTest {
 
   @Test
   public void nullGraphConstructor() {
-    assertThrows(IllegalArgumentException.class, () -> new TarjanSccSolverAdjacencyList(null));
+    assertThrows(NullPointerException.class, () -> new TarjanSccSolverAdjacencyList(null));
   }
 
   @Test


### PR DESCRIPTION
This PR changes the types of exceptions being thrown by the methods, including:

- Removes uses of `java.lang.Exception` (way too broad)
- Replaces uses of `java.lang.RuntimeException` with more appropriate subclasses of it
- Replaces uses of `java.lang.IllegalArgumentException` for invalid `null` arguments with `java.lang.NullPointerException` (mostly via `java.util.Objects.requireNonNull(Object)`)
  > Applications should throw instances of this class to indicate other illegal uses of the null object.
  > _[Java 11 API: `java.lang.NullPointerException`](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/NullPointerException.html)_
- Replaces uses of `java.lang.IllegalArgumentException` for invalid index with `java.lang.IndexOutOfBoundsException`
- Etc.