### PR TITLE
Add LCP check to fix toString in SuffixArray

### DIFF
--- a/src/main/java/com/williamfiset/algorithms/datastructures/suffixarray/SuffixArray.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/suffixarray/SuffixArray.java
@@ -88,6 +88,7 @@ public abstract class SuffixArray {
 
   @Override
   public String toString() {
+    if (!constructedLcpArray) buildLcpArray();
     StringBuilder sb = new StringBuilder();
     sb.append("-----i-----SA-----LCP---Suffix\n");
 


### PR DESCRIPTION
Issue: 
When toString() was invoked just after creating the Suffix Array data structure, it gave null pointer exception when accessing actual array data member (sa) as the Suffix array and LCP array were not yet constructed.
Fix:
Added a check to see if LCP was constructed before printing out the data members and construct them if needed.