### PR TITLE
Refactor LCA Euler Tour: cleanup, bazel docs, expand tests

### DIFF
--- a/src/main/java/com/williamfiset/algorithms/graphtheory/treealgorithms/LowestCommonAncestorEulerTour.java
+++ b/src/main/java/com/williamfiset/algorithms/graphtheory/treealgorithms/LowestCommonAncestorEulerTour.java
@@ -8,9 +8,10 @@
  *
  * <p>Space Complexity: O(n*log2(n))
  *
- * <p>To run script:
+ * <p>Run tests:
  *
- * <p>./gradlew run -Palgorithm=graphtheory.treealgorithms.LowestCommonAncestorEulerTour
+ * <p>bazel test
+ * //src/test/java/com/williamfiset/algorithms/graphtheory/treealgorithms:LowestCommonAncestorEulerTourTest
  *
  * @author William Fiset
  */
@@ -19,70 +20,6 @@ package com.williamfiset.algorithms.graphtheory.treealgorithms;
 import java.util.*;
 
 public class LowestCommonAncestorEulerTour {
-
-  public static void main(String[] args) {
-    TreeNode root = createFirstTreeFromSlides();
-    LowestCommonAncestorEulerTour solver = new LowestCommonAncestorEulerTour(root);
-
-    // LCA of 13 and 14 = 2
-    TreeNode lca = solver.lca(13, 14);
-    System.out.printf("LCA of 13 and 14 = %s\n", lca);
-    if (lca.index() != 2) {
-      System.out.println("Error, expected lca to be 2");
-    }
-
-    // LCA of 9 and 11 = 0
-    lca = solver.lca(9, 11);
-    System.out.printf("LCA of 9 and 11 = %s\n", lca);
-    if (lca.index() != 0) {
-      System.out.println("Error, expected lca to be 0");
-    }
-
-    // LCA of 12 and 12 = 12
-    lca = solver.lca(12, 12);
-    System.out.printf("LCA of 12 and 12 = %s\n", lca);
-    if (lca.index() != 12) {
-      System.out.println("Error, expected lca to be 12");
-    }
-  }
-
-  private static TreeNode createFirstTreeFromSlides() {
-    int n = 17;
-    List<List<Integer>> tree = createEmptyGraph(n);
-
-    addUndirectedEdge(tree, 0, 1);
-    addUndirectedEdge(tree, 0, 2);
-    addUndirectedEdge(tree, 1, 3);
-    addUndirectedEdge(tree, 1, 4);
-    addUndirectedEdge(tree, 2, 5);
-    addUndirectedEdge(tree, 2, 6);
-    addUndirectedEdge(tree, 2, 7);
-    addUndirectedEdge(tree, 3, 8);
-    addUndirectedEdge(tree, 3, 9);
-    addUndirectedEdge(tree, 5, 10);
-    addUndirectedEdge(tree, 5, 11);
-    addUndirectedEdge(tree, 7, 12);
-    addUndirectedEdge(tree, 7, 13);
-    addUndirectedEdge(tree, 11, 14);
-    addUndirectedEdge(tree, 11, 15);
-    addUndirectedEdge(tree, 11, 16);
-
-    return TreeNode.rootTree(tree, 0);
-  }
-
-  /* Graph/Tree creation helper methods. */
-
-  // Create a graph as a adjacency list with 'n' nodes.
-  public static List<List<Integer>> createEmptyGraph(int n) {
-    List<List<Integer>> graph = new ArrayList<>(n);
-    for (int i = 0; i < n; i++) graph.add(new LinkedList<>());
-    return graph;
-  }
-
-  public static void addUndirectedEdge(List<List<Integer>> graph, int from, int to) {
-    graph.get(from).add(to);
-    graph.get(to).add(from);
-  }
 
   public static class TreeNode {
     // Number of nodes in the subtree. Computed when tree is built.
@@ -100,7 +37,7 @@ public class LowestCommonAncestorEulerTour {
     public TreeNode(int index, TreeNode parent) {
       this.index = index;
       this.parent = parent;
-      children = new LinkedList<>();
+      children = new ArrayList<>();
     }
 
     public void addChildren(TreeNode... nodes) {
@@ -134,8 +71,8 @@ public class LowestCommonAncestorEulerTour {
       TreeNode root = new TreeNode(rootId);
       TreeNode rootedTree = buildTree(graph, root);
       if (rootedTree.size() < graph.size()) {
-        System.out.println(
-            "WARNING: Input graph malformed. Did you forget to include all n-1 edges?");
+        throw new IllegalArgumentException(
+            "Input graph malformed. Did you forget to include all n-1 edges?");
       }
       return rootedTree;
     }
@@ -227,6 +164,20 @@ public class LowestCommonAncestorEulerTour {
     return nodeOrder[i];
   }
 
+  /* Graph/Tree creation helper methods. */
+
+  // Create a graph as an adjacency list with 'n' nodes.
+  public static List<List<Integer>> createEmptyGraph(int n) {
+    List<List<Integer>> graph = new ArrayList<>(n);
+    for (int i = 0; i < n; i++) graph.add(new ArrayList<>());
+    return graph;
+  }
+
+  public static void addUndirectedEdge(List<List<Integer>> graph, int from, int to) {
+    graph.get(from).add(to);
+    graph.get(to).add(from);
+  }
+
   // Sparse table for efficient minimum range queries in O(1) with O(nlogn) space
   private static class MinSparseTable {
 
@@ -294,5 +245,46 @@ public class LowestCommonAncestorEulerTour {
         return it[p][r - (1 << p) + 1];
       }
     }
+  }
+
+  public static void main(String[] args) {
+    TreeNode root = createSampleTree();
+    LowestCommonAncestorEulerTour solver = new LowestCommonAncestorEulerTour(root);
+
+    // LCA of 13 and 14 = 2
+    TreeNode lca = solver.lca(13, 14);
+    System.out.printf("LCA of 13 and 14 = %s\n", lca);
+
+    // LCA of 9 and 11 = 0
+    lca = solver.lca(9, 11);
+    System.out.printf("LCA of 9 and 11 = %s\n", lca);
+
+    // LCA of 12 and 12 = 12
+    lca = solver.lca(12, 12);
+    System.out.printf("LCA of 12 and 12 = %s\n", lca);
+  }
+
+  private static TreeNode createSampleTree() {
+    int n = 17;
+    List<List<Integer>> tree = createEmptyGraph(n);
+
+    addUndirectedEdge(tree, 0, 1);
+    addUndirectedEdge(tree, 0, 2);
+    addUndirectedEdge(tree, 1, 3);
+    addUndirectedEdge(tree, 1, 4);
+    addUndirectedEdge(tree, 2, 5);
+    addUndirectedEdge(tree, 2, 6);
+    addUndirectedEdge(tree, 2, 7);
+    addUndirectedEdge(tree, 3, 8);
+    addUndirectedEdge(tree, 3, 9);
+    addUndirectedEdge(tree, 5, 10);
+    addUndirectedEdge(tree, 5, 11);
+    addUndirectedEdge(tree, 7, 12);
+    addUndirectedEdge(tree, 7, 13);
+    addUndirectedEdge(tree, 11, 14);
+    addUndirectedEdge(tree, 11, 15);
+    addUndirectedEdge(tree, 11, 16);
+
+    return TreeNode.rootTree(tree, 0);
   }
 }

--- a/src/test/java/com/williamfiset/algorithms/graphtheory/treealgorithms/LowestCommonAncestorEulerTourTest.java
+++ b/src/test/java/com/williamfiset/algorithms/graphtheory/treealgorithms/LowestCommonAncestorEulerTourTest.java
@@ -1,6 +1,7 @@
 package com.williamfiset.algorithms.graphtheory.treealgorithms;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.*;
 import org.junit.jupiter.api.*;
@@ -61,6 +62,123 @@ public class LowestCommonAncestorEulerTourTest {
     for (int id = 0; id < root.size(); id++) {
       assertThat(fastSolver.lca(id, id).index()).isEqualTo(id);
     }
+  }
+
+  @Test
+  public void testLcaIsSymmetric() {
+    LowestCommonAncestorEulerTour.TreeNode root = createFirstTreeFromSlides();
+    LowestCommonAncestorEulerTour solver = new LowestCommonAncestorEulerTour(root);
+
+    // LCA(a, b) should equal LCA(b, a) for all pairs
+    for (int i = 0; i < root.size(); i++) {
+      for (int j = i + 1; j < root.size(); j++) {
+        assertThat(solver.lca(i, j).index()).isEqualTo(solver.lca(j, i).index());
+      }
+    }
+  }
+
+  @Test
+  public void testLcaRootIsAlwaysAncestor() {
+    LowestCommonAncestorEulerTour.TreeNode root = createFirstTreeFromSlides();
+    LowestCommonAncestorEulerTour solver = new LowestCommonAncestorEulerTour(root);
+
+    // LCA of root with any node should be root
+    for (int i = 0; i < root.size(); i++) {
+      assertThat(solver.lca(0, i).index()).isEqualTo(0);
+    }
+  }
+
+  @Test
+  public void testLcaParentChild() {
+    LowestCommonAncestorEulerTour.TreeNode root = createFirstTreeFromSlides();
+    LowestCommonAncestorEulerTour solver = new LowestCommonAncestorEulerTour(root);
+
+    // LCA of a parent and its direct child is the parent
+    // Node 1's children are 3 and 4
+    assertThat(solver.lca(1, 3).index()).isEqualTo(1);
+    assertThat(solver.lca(1, 4).index()).isEqualTo(1);
+    // Node 2's children are 5, 6, 7
+    assertThat(solver.lca(2, 5).index()).isEqualTo(2);
+    assertThat(solver.lca(2, 7).index()).isEqualTo(2);
+    // Node 11's children are 14, 15, 16
+    assertThat(solver.lca(11, 14).index()).isEqualTo(11);
+  }
+
+  @Test
+  public void testSingleNodeTree() {
+    List<List<Integer>> tree = LowestCommonAncestorEulerTour.createEmptyGraph(1);
+    LowestCommonAncestorEulerTour.TreeNode root =
+        LowestCommonAncestorEulerTour.TreeNode.rootTree(tree, 0);
+
+    LowestCommonAncestorEulerTour solver = new LowestCommonAncestorEulerTour(root);
+    assertThat(solver.lca(0, 0).index()).isEqualTo(0);
+  }
+
+  @Test
+  public void testTwoNodeTree() {
+    List<List<Integer>> tree = LowestCommonAncestorEulerTour.createEmptyGraph(2);
+    LowestCommonAncestorEulerTour.addUndirectedEdge(tree, 0, 1);
+    LowestCommonAncestorEulerTour.TreeNode root =
+        LowestCommonAncestorEulerTour.TreeNode.rootTree(tree, 0);
+
+    LowestCommonAncestorEulerTour solver = new LowestCommonAncestorEulerTour(root);
+    assertThat(solver.lca(0, 1).index()).isEqualTo(0);
+    assertThat(solver.lca(1, 0).index()).isEqualTo(0);
+    assertThat(solver.lca(1, 1).index()).isEqualTo(1);
+  }
+
+  @Test
+  public void testLinearChainTree() {
+    // Build a chain: 0 - 1 - 2 - 3 - 4
+    int n = 5;
+    List<List<Integer>> tree = LowestCommonAncestorEulerTour.createEmptyGraph(n);
+    for (int i = 0; i < n - 1; i++) {
+      LowestCommonAncestorEulerTour.addUndirectedEdge(tree, i, i + 1);
+    }
+    LowestCommonAncestorEulerTour.TreeNode root =
+        LowestCommonAncestorEulerTour.TreeNode.rootTree(tree, 0);
+
+    LowestCommonAncestorEulerTour solver = new LowestCommonAncestorEulerTour(root);
+
+    // In a chain rooted at 0, LCA of any two nodes is the one closer to root
+    assertThat(solver.lca(0, 4).index()).isEqualTo(0);
+    assertThat(solver.lca(1, 4).index()).isEqualTo(1);
+    assertThat(solver.lca(2, 4).index()).isEqualTo(2);
+    assertThat(solver.lca(3, 4).index()).isEqualTo(3);
+    assertThat(solver.lca(1, 3).index()).isEqualTo(1);
+  }
+
+  @Test
+  public void testTreeNodeProperties() {
+    LowestCommonAncestorEulerTour.TreeNode root = createFirstTreeFromSlides();
+
+    assertThat(root.index()).isEqualTo(0);
+    assertThat(root.parent()).isNull();
+    assertThat(root.size()).isEqualTo(17);
+    assertThat(root.children()).hasSize(2);
+    assertThat(root.toString()).isEqualTo("0");
+  }
+
+  @Test
+  public void testTreeNodeChildProperties() {
+    LowestCommonAncestorEulerTour.TreeNode root = createFirstTreeFromSlides();
+
+    // Node 1 (first child of root)
+    LowestCommonAncestorEulerTour.TreeNode node1 = root.children().get(0);
+    assertThat(node1.index()).isEqualTo(1);
+    assertThat(node1.parent().index()).isEqualTo(0);
+    assertThat(node1.children()).hasSize(2); // children: 3, 4
+  }
+
+  @Test
+  public void testMalformedGraphThrows() {
+    // Graph with 3 nodes but only 1 edge (disconnected)
+    List<List<Integer>> tree = LowestCommonAncestorEulerTour.createEmptyGraph(3);
+    LowestCommonAncestorEulerTour.addUndirectedEdge(tree, 0, 1);
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> LowestCommonAncestorEulerTour.TreeNode.rootTree(tree, 0));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Replace gradle run instructions with bazel test command in javadoc
- Move `main` method to bottom, `TreeNode` class to top for better readability
- Replace `System.out.println` warning in `rootTree` with `IllegalArgumentException` for malformed graphs
- Replace `LinkedList` with `ArrayList` for children lists and adjacency lists
- Expand test suite from 4 to 12 tests covering symmetry, root ancestry, parent-child LCA, edge cases (single/two node trees, linear chains), TreeNode properties, and malformed graph detection

## Test plan
- [x] All 12 tests pass via `bazel test`
- [x] Existing randomized cross-validation test against `LowestCommonAncestor` unchanged and passing
- [x] New tests cover edge cases and structural properties of LCA

🤖 Generated with [Claude Code](https://claude.com/claude-code)