### PR TITLE
Fix BucketSort bug, remove gradle refs, add sorting tests

### DIFF
--- a/src/main/java/com/williamfiset/algorithms/sorting/BubbleSort.java
+++ b/src/main/java/com/williamfiset/algorithms/sorting/BubbleSort.java
@@ -1,10 +1,6 @@
 /**
  * Bubble sort implementation
  *
- * <p>Run with:
- *
- * <p>$ ./gradlew run -Palgorithm=sorting.BubbleSort
- *
  * @author William Fiset, william.alexandre.fiset@gmail.com
  */
 package com.williamfiset.algorithms.sorting;

--- a/src/main/java/com/williamfiset/algorithms/sorting/BucketSort.java
+++ b/src/main/java/com/williamfiset/algorithms/sorting/BucketSort.java
@@ -1,10 +1,6 @@
 /**
  * Bucket sort implementation
  *
- * <p>Run with:
- *
- * <p>$ ./gradlew run -Palgorithm=sorting.BucketSort
- *
  * @author William Fiset, william.alexandre.fiset@gmail.com
  */
 package com.williamfiset.algorithms.sorting;
@@ -37,7 +33,7 @@ public class BucketSort implements InplaceSort {
 
     // Place each element in a bucket
     for (int i = 0; i < N; i++) {
-      int bi = (ar[i] - minValue) / M;
+      int bi = (ar[i] - minValue) / N;
       List<Integer> bucket = buckets.get(bi);
       bucket.add(ar[i]);
     }

--- a/src/main/java/com/williamfiset/algorithms/sorting/CountingSort.java
+++ b/src/main/java/com/williamfiset/algorithms/sorting/CountingSort.java
@@ -1,10 +1,6 @@
 /**
  * An implementation of counting sort!
  *
- * <p>Run with:
- *
- * <p>$ ./gradlew run -Palgorithm=sorting.CountingSort
- *
  * @author William Fiset, william.alexandre.fiset@gmail.com
  */
 package com.williamfiset.algorithms.sorting;

--- a/src/main/java/com/williamfiset/algorithms/sorting/Heapsort.java
+++ b/src/main/java/com/williamfiset/algorithms/sorting/Heapsort.java
@@ -1,10 +1,6 @@
 /**
  * Implementation of heapsort
  *
- * <p>Run with:
- *
- * <p>$ ./gradlew run -Palgorithm=sorting.Heapsort
- *
  * @author William Fiset, william.alexandre.fiset@gmail.com
  */
 package com.williamfiset.algorithms.sorting;

--- a/src/main/java/com/williamfiset/algorithms/sorting/InsertionSort.java
+++ b/src/main/java/com/williamfiset/algorithms/sorting/InsertionSort.java
@@ -1,10 +1,6 @@
 /**
  * Insertion sort implementation
  *
- * <p>Run with:
- *
- * <p>$ ./gradlew run -Palgorithm=sorting.InsertionSort
- *
  * @author William Fiset, william.alexandre.fiset@gmail.com
  */
 package com.williamfiset.algorithms.sorting;

--- a/src/main/java/com/williamfiset/algorithms/sorting/MergeSort.java
+++ b/src/main/java/com/williamfiset/algorithms/sorting/MergeSort.java
@@ -1,10 +1,6 @@
 /**
  * Mergesort implementation
  *
- * <p>Run with:
- *
- * <p>$ ./gradlew run -Palgorithm=sorting.Mergesort
- *
  * @author William Fiset, william.alexandre.fiset@gmail.com
  */
 package com.williamfiset.algorithms.sorting;

--- a/src/main/java/com/williamfiset/algorithms/sorting/QuickSort.java
+++ b/src/main/java/com/williamfiset/algorithms/sorting/QuickSort.java
@@ -1,10 +1,6 @@
 /**
  * Quicksort implementation using Hoare partitioning
  *
- * <p>Run with:
- *
- * <p>$ ./gradlew run -Palgorithm=sorting.QuickSort
- *
  * @author William Fiset, william.alexandre.fiset@gmail.com
  */
 package com.williamfiset.algorithms.sorting;

--- a/src/main/java/com/williamfiset/algorithms/sorting/QuickSort3.java
+++ b/src/main/java/com/williamfiset/algorithms/sorting/QuickSort3.java
@@ -3,10 +3,6 @@
  * improved partitioning algorithm. QuickSort is quite slow in the case where very few unique
  * elements exist in the array so the QuickSort3 algorithm is used at that time.
  *
- * <p>Run with:
- *
- * <p>$ ./gradlew run -Palgorithm=sorting.QuickSort3
- *
  * @author Atharva Thorve, aaathorve@gmail.com
  */
 package com.williamfiset.algorithms.sorting;

--- a/src/main/java/com/williamfiset/algorithms/sorting/RadixSort.java
+++ b/src/main/java/com/williamfiset/algorithms/sorting/RadixSort.java
@@ -8,10 +8,6 @@
  *
  * <p>Time Complexity: O(nw)
  *
- * <p>Run with:
- *
- * <p>$ ./gradlew run -Palgorithm=sorting.RadixSort
- *
  * @author EAlexa
  */
 package com.williamfiset.algorithms.sorting;

--- a/src/main/java/com/williamfiset/algorithms/sorting/SelectionSort.java
+++ b/src/main/java/com/williamfiset/algorithms/sorting/SelectionSort.java
@@ -1,10 +1,6 @@
 /**
  * Selection sort implementation
  *
- * <p>Run with:
- *
- * <p>$ ./gradlew run -Palgorithm=sorting.SelectionSort
- *
  * @author William Fiset, william.alexandre.fiset@gmail.com
  */
 package com.williamfiset.algorithms.sorting;

--- a/src/test/java/com/williamfiset/algorithms/sorting/BUILD
+++ b/src/test/java/com/williamfiset/algorithms/sorting/BUILD
@@ -18,6 +18,56 @@ TEST_DEPS = [
 ] + JUNIT5_DEPS
 
 java_test(
+    name = "BubbleSortTest",
+    srcs = ["BubbleSortTest.java"],
+    main_class = "org.junit.platform.console.ConsoleLauncher",
+    use_testrunner = False,
+    args = ["--select-class=com.williamfiset.algorithms.sorting.BubbleSortTest"],
+    runtime_deps = JUNIT5_RUNTIME_DEPS,
+    deps = TEST_DEPS,
+)
+
+java_test(
+    name = "CountingSortTest",
+    srcs = ["CountingSortTest.java"],
+    main_class = "org.junit.platform.console.ConsoleLauncher",
+    use_testrunner = False,
+    args = ["--select-class=com.williamfiset.algorithms.sorting.CountingSortTest"],
+    runtime_deps = JUNIT5_RUNTIME_DEPS,
+    deps = TEST_DEPS,
+)
+
+java_test(
+    name = "HeapsortTest",
+    srcs = ["HeapsortTest.java"],
+    main_class = "org.junit.platform.console.ConsoleLauncher",
+    use_testrunner = False,
+    args = ["--select-class=com.williamfiset.algorithms.sorting.HeapsortTest"],
+    runtime_deps = JUNIT5_RUNTIME_DEPS,
+    deps = TEST_DEPS,
+)
+
+java_test(
+    name = "InsertionSortTest",
+    srcs = ["InsertionSortTest.java"],
+    main_class = "org.junit.platform.console.ConsoleLauncher",
+    use_testrunner = False,
+    args = ["--select-class=com.williamfiset.algorithms.sorting.InsertionSortTest"],
+    runtime_deps = JUNIT5_RUNTIME_DEPS,
+    deps = TEST_DEPS,
+)
+
+java_test(
+    name = "MergeSortTest",
+    srcs = ["MergeSortTest.java"],
+    main_class = "org.junit.platform.console.ConsoleLauncher",
+    use_testrunner = False,
+    args = ["--select-class=com.williamfiset.algorithms.sorting.MergeSortTest"],
+    runtime_deps = JUNIT5_RUNTIME_DEPS,
+    deps = TEST_DEPS,
+)
+
+java_test(
     name = "QuickSelectTest",
     srcs = ["QuickSelectTest.java"],
     main_class = "org.junit.platform.console.ConsoleLauncher",
@@ -33,6 +83,46 @@ java_test(
     main_class = "org.junit.platform.console.ConsoleLauncher",
     use_testrunner = False,
     args = ["--select-class=com.williamfiset.algorithms.sorting.RadixSortTest"],
+    runtime_deps = JUNIT5_RUNTIME_DEPS,
+    deps = TEST_DEPS,
+)
+
+java_test(
+    name = "QuickSortTest",
+    srcs = ["QuickSortTest.java"],
+    main_class = "org.junit.platform.console.ConsoleLauncher",
+    use_testrunner = False,
+    args = ["--select-class=com.williamfiset.algorithms.sorting.QuickSortTest"],
+    runtime_deps = JUNIT5_RUNTIME_DEPS,
+    deps = TEST_DEPS,
+)
+
+java_test(
+    name = "QuickSort3Test",
+    srcs = ["QuickSort3Test.java"],
+    main_class = "org.junit.platform.console.ConsoleLauncher",
+    use_testrunner = False,
+    args = ["--select-class=com.williamfiset.algorithms.sorting.QuickSort3Test"],
+    runtime_deps = JUNIT5_RUNTIME_DEPS,
+    deps = TEST_DEPS,
+)
+
+java_test(
+    name = "SelectionSortTest",
+    srcs = ["SelectionSortTest.java"],
+    main_class = "org.junit.platform.console.ConsoleLauncher",
+    use_testrunner = False,
+    args = ["--select-class=com.williamfiset.algorithms.sorting.SelectionSortTest"],
+    runtime_deps = JUNIT5_RUNTIME_DEPS,
+    deps = TEST_DEPS,
+)
+
+java_test(
+    name = "BucketSortTest",
+    srcs = ["BucketSortTest.java"],
+    main_class = "org.junit.platform.console.ConsoleLauncher",
+    use_testrunner = False,
+    args = ["--select-class=com.williamfiset.algorithms.sorting.BucketSortTest"],
     runtime_deps = JUNIT5_RUNTIME_DEPS,
     deps = TEST_DEPS,
 )

--- a/src/test/java/com/williamfiset/algorithms/sorting/BubbleSortTest.java
+++ b/src/test/java/com/williamfiset/algorithms/sorting/BubbleSortTest.java
@@ -1,0 +1,86 @@
+package com.williamfiset.algorithms.sorting;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.williamfiset.algorithms.utils.TestUtils;
+import java.util.Arrays;
+import org.junit.jupiter.api.*;
+
+public class BubbleSortTest {
+
+  private final BubbleSort sorter = new BubbleSort();
+
+  @Test
+  public void testEmptyArray() {
+    int[] array = {};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {});
+  }
+
+  @Test
+  public void testSingleElement() {
+    int[] array = {7};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {7});
+  }
+
+  @Test
+  public void testAlreadySorted() {
+    int[] array = {1, 2, 3, 4, 5};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {1, 2, 3, 4, 5});
+  }
+
+  @Test
+  public void testReverseSorted() {
+    int[] array = {5, 4, 3, 2, 1};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {1, 2, 3, 4, 5});
+  }
+
+  @Test
+  public void testWithDuplicates() {
+    int[] array = {3, 1, 4, 1, 5, 9, 2, 6, 5, 3};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {1, 1, 2, 3, 3, 4, 5, 5, 6, 9});
+  }
+
+  @Test
+  public void testAllSameElements() {
+    int[] array = {5, 5, 5, 5};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {5, 5, 5, 5});
+  }
+
+  @Test
+  public void testNegativeNumbers() {
+    int[] array = {-3, -1, -4, -1, -5};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {-5, -4, -3, -1, -1});
+  }
+
+  @Test
+  public void testMixedPositiveAndNegative() {
+    int[] array = {3, -2, 0, 7, -5, 1};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {-5, -2, 0, 1, 3, 7});
+  }
+
+  @Test
+  public void testTwoElements() {
+    int[] array = {9, 1};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {1, 9});
+  }
+
+  @Test
+  public void testRandomized() {
+    for (int size = 0; size < 200; size++) {
+      int[] values = TestUtils.randomIntegerArray(size, -50, 51);
+      int[] expected = values.clone();
+      Arrays.sort(expected);
+      sorter.sort(values);
+      assertThat(values).isEqualTo(expected);
+    }
+  }
+}

--- a/src/test/java/com/williamfiset/algorithms/sorting/BucketSortTest.java
+++ b/src/test/java/com/williamfiset/algorithms/sorting/BucketSortTest.java
@@ -1,0 +1,131 @@
+package com.williamfiset.algorithms.sorting;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.williamfiset.algorithms.utils.TestUtils;
+import java.util.Arrays;
+import org.junit.jupiter.api.*;
+
+public class BucketSortTest {
+
+  private final BucketSort sorter = new BucketSort();
+
+  @Test
+  public void testEmptyArray() {
+    int[] array = {};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {});
+  }
+
+  @Test
+  public void testSingleElement() {
+    int[] array = {42};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {42});
+  }
+
+  @Test
+  public void testAllSameElements() {
+    int[] array = {5, 5, 5, 5, 5};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {5, 5, 5, 5, 5});
+  }
+
+  @Test
+  public void testAlreadySorted() {
+    int[] array = {1, 2, 3, 4, 5};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {1, 2, 3, 4, 5});
+  }
+
+  @Test
+  public void testReverseSorted() {
+    int[] array = {5, 4, 3, 2, 1};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {1, 2, 3, 4, 5});
+  }
+
+  @Test
+  public void testWithDuplicates() {
+    int[] array = {3, 1, 4, 1, 5, 9, 2, 6, 5, 3};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {1, 1, 2, 3, 3, 4, 5, 5, 6, 9});
+  }
+
+  @Test
+  public void testNegativeNumbers() {
+    int[] array = {-3, -1, -4, -1, -5};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {-5, -4, -3, -1, -1});
+  }
+
+  @Test
+  public void testMixedPositiveAndNegative() {
+    int[] array = {3, -2, 0, 7, -5, 1};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {-5, -2, 0, 1, 3, 7});
+  }
+
+  @Test
+  public void testTwoElements() {
+    int[] array = {9, 1};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {1, 9});
+  }
+
+  @Test
+  public void testLargeRange() {
+    int[] array = {1000, 1, 500, 250, 750};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {1, 250, 500, 750, 1000});
+  }
+
+  @Test
+  public void testRangeGreaterThanN() {
+    // Range (M) much larger than number of elements (N) to exercise multiple buckets
+    int[] array = {100, 1, 50, 99, 2};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {1, 2, 50, 99, 100});
+  }
+
+  @Test
+  public void testRangeSmallerThanN() {
+    // Range (M) smaller than number of elements (N), most elements share a bucket
+    int[] array = {3, 1, 2, 1, 3, 2, 1, 3, 2, 1};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {1, 1, 1, 1, 2, 2, 2, 3, 3, 3});
+  }
+
+  @Test
+  public void testRandomizedSmall() {
+    for (int size = 0; size < 500; size++) {
+      int[] values = TestUtils.randomIntegerArray(size, 0, 51);
+      int[] expected = values.clone();
+      Arrays.sort(expected);
+      sorter.sort(values);
+      assertThat(values).isEqualTo(expected);
+    }
+  }
+
+  @Test
+  public void testRandomizedWithNegatives() {
+    for (int size = 1; size < 500; size++) {
+      int[] values = TestUtils.randomIntegerArray(size, -50, 51);
+      int[] expected = values.clone();
+      Arrays.sort(expected);
+      sorter.sort(values);
+      assertThat(values).isEqualTo(expected);
+    }
+  }
+
+  @Test
+  public void testRandomizedLargeRange() {
+    for (int size = 1; size < 200; size++) {
+      int[] values = TestUtils.randomIntegerArray(size, -10000, 10001);
+      int[] expected = values.clone();
+      Arrays.sort(expected);
+      sorter.sort(values);
+      assertThat(values).isEqualTo(expected);
+    }
+  }
+}

--- a/src/test/java/com/williamfiset/algorithms/sorting/CountingSortTest.java
+++ b/src/test/java/com/williamfiset/algorithms/sorting/CountingSortTest.java
@@ -1,0 +1,86 @@
+package com.williamfiset.algorithms.sorting;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.williamfiset.algorithms.utils.TestUtils;
+import java.util.Arrays;
+import org.junit.jupiter.api.*;
+
+public class CountingSortTest {
+
+  private final CountingSort sorter = new CountingSort();
+
+  @Test
+  public void testEmptyArray() {
+    int[] array = {};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {});
+  }
+
+  @Test
+  public void testSingleElement() {
+    int[] array = {42};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {42});
+  }
+
+  @Test
+  public void testAlreadySorted() {
+    int[] array = {1, 2, 3, 4, 5};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {1, 2, 3, 4, 5});
+  }
+
+  @Test
+  public void testReverseSorted() {
+    int[] array = {5, 4, 3, 2, 1};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {1, 2, 3, 4, 5});
+  }
+
+  @Test
+  public void testWithDuplicates() {
+    int[] array = {3, 1, 4, 1, 5, 9, 2, 6, 5, 3};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {1, 1, 2, 3, 3, 4, 5, 5, 6, 9});
+  }
+
+  @Test
+  public void testAllSameElements() {
+    int[] array = {7, 7, 7, 7};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {7, 7, 7, 7});
+  }
+
+  @Test
+  public void testNegativeNumbers() {
+    int[] array = {-3, -1, -4, -1, -5};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {-5, -4, -3, -1, -1});
+  }
+
+  @Test
+  public void testMixedPositiveAndNegative() {
+    int[] array = {4, -10, 0, 6, 1, -5, -5, 1, 1, -2, 0, 6, 8, -7, 10};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {-10, -7, -5, -5, -2, 0, 0, 1, 1, 1, 4, 6, 6, 8, 10});
+  }
+
+  @Test
+  public void testTwoElements() {
+    int[] array = {9, 1};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {1, 9});
+  }
+
+  @Test
+  public void testRandomized() {
+    for (int size = 0; size < 500; size++) {
+      int[] values = TestUtils.randomIntegerArray(size, -50, 51);
+      int[] expected = values.clone();
+      Arrays.sort(expected);
+      sorter.sort(values);
+      assertThat(values).isEqualTo(expected);
+    }
+  }
+}

--- a/src/test/java/com/williamfiset/algorithms/sorting/HeapsortTest.java
+++ b/src/test/java/com/williamfiset/algorithms/sorting/HeapsortTest.java
@@ -1,0 +1,86 @@
+package com.williamfiset.algorithms.sorting;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.williamfiset.algorithms.utils.TestUtils;
+import java.util.Arrays;
+import org.junit.jupiter.api.*;
+
+public class HeapsortTest {
+
+  private final Heapsort sorter = new Heapsort();
+
+  @Test
+  public void testEmptyArray() {
+    int[] array = {};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {});
+  }
+
+  @Test
+  public void testSingleElement() {
+    int[] array = {42};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {42});
+  }
+
+  @Test
+  public void testAlreadySorted() {
+    int[] array = {1, 2, 3, 4, 5};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {1, 2, 3, 4, 5});
+  }
+
+  @Test
+  public void testReverseSorted() {
+    int[] array = {5, 4, 3, 2, 1};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {1, 2, 3, 4, 5});
+  }
+
+  @Test
+  public void testWithDuplicates() {
+    int[] array = {10, 4, 6, 4, 8, -13, 2, 3};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {-13, 2, 3, 4, 4, 6, 8, 10});
+  }
+
+  @Test
+  public void testAllSameElements() {
+    int[] array = {3, 3, 3, 3, 3};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {3, 3, 3, 3, 3});
+  }
+
+  @Test
+  public void testNegativeNumbers() {
+    int[] array = {-3, -1, -4, -1, -5};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {-5, -4, -3, -1, -1});
+  }
+
+  @Test
+  public void testMixedPositiveAndNegative() {
+    int[] array = {3, -2, 0, 7, -5, 1};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {-5, -2, 0, 1, 3, 7});
+  }
+
+  @Test
+  public void testTwoElements() {
+    int[] array = {9, 1};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {1, 9});
+  }
+
+  @Test
+  public void testRandomized() {
+    for (int size = 0; size < 500; size++) {
+      int[] values = TestUtils.randomIntegerArray(size, -50, 51);
+      int[] expected = values.clone();
+      Arrays.sort(expected);
+      sorter.sort(values);
+      assertThat(values).isEqualTo(expected);
+    }
+  }
+}

--- a/src/test/java/com/williamfiset/algorithms/sorting/InsertionSortTest.java
+++ b/src/test/java/com/williamfiset/algorithms/sorting/InsertionSortTest.java
@@ -1,0 +1,86 @@
+package com.williamfiset.algorithms.sorting;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.williamfiset.algorithms.utils.TestUtils;
+import java.util.Arrays;
+import org.junit.jupiter.api.*;
+
+public class InsertionSortTest {
+
+  private final InsertionSort sorter = new InsertionSort();
+
+  @Test
+  public void testEmptyArray() {
+    int[] array = {};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {});
+  }
+
+  @Test
+  public void testSingleElement() {
+    int[] array = {42};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {42});
+  }
+
+  @Test
+  public void testAlreadySorted() {
+    int[] array = {1, 2, 3, 4, 5};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {1, 2, 3, 4, 5});
+  }
+
+  @Test
+  public void testReverseSorted() {
+    int[] array = {5, 4, 3, 2, 1};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {1, 2, 3, 4, 5});
+  }
+
+  @Test
+  public void testWithDuplicates() {
+    int[] array = {3, 1, 4, 1, 5, 9, 2, 6, 5, 3};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {1, 1, 2, 3, 3, 4, 5, 5, 6, 9});
+  }
+
+  @Test
+  public void testAllSameElements() {
+    int[] array = {4, 4, 4, 4};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {4, 4, 4, 4});
+  }
+
+  @Test
+  public void testNegativeNumbers() {
+    int[] array = {-3, -1, -4, -1, -5};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {-5, -4, -3, -1, -1});
+  }
+
+  @Test
+  public void testMixedPositiveAndNegative() {
+    int[] array = {3, -2, 0, 7, -5, 1};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {-5, -2, 0, 1, 3, 7});
+  }
+
+  @Test
+  public void testTwoElements() {
+    int[] array = {9, 1};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {1, 9});
+  }
+
+  @Test
+  public void testRandomized() {
+    for (int size = 0; size < 200; size++) {
+      int[] values = TestUtils.randomIntegerArray(size, -50, 51);
+      int[] expected = values.clone();
+      Arrays.sort(expected);
+      sorter.sort(values);
+      assertThat(values).isEqualTo(expected);
+    }
+  }
+}

--- a/src/test/java/com/williamfiset/algorithms/sorting/MergeSortTest.java
+++ b/src/test/java/com/williamfiset/algorithms/sorting/MergeSortTest.java
@@ -1,0 +1,93 @@
+package com.williamfiset.algorithms.sorting;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.williamfiset.algorithms.utils.TestUtils;
+import java.util.Arrays;
+import org.junit.jupiter.api.*;
+
+public class MergeSortTest {
+
+  private final MergeSort sorter = new MergeSort();
+
+  @Test
+  public void testEmptyArray() {
+    int[] array = {};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {});
+  }
+
+  @Test
+  public void testSingleElement() {
+    int[] array = {42};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {42});
+  }
+
+  @Test
+  public void testAlreadySorted() {
+    int[] array = {1, 2, 3, 4, 5};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {1, 2, 3, 4, 5});
+  }
+
+  @Test
+  public void testReverseSorted() {
+    int[] array = {5, 4, 3, 2, 1};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {1, 2, 3, 4, 5});
+  }
+
+  @Test
+  public void testWithDuplicates() {
+    int[] array = {3, 1, 4, 1, 5, 9, 2, 6, 5, 3};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {1, 1, 2, 3, 3, 4, 5, 5, 6, 9});
+  }
+
+  @Test
+  public void testAllSameElements() {
+    int[] array = {6, 6, 6, 6};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {6, 6, 6, 6});
+  }
+
+  @Test
+  public void testNegativeNumbers() {
+    int[] array = {-3, -1, -4, -1, -5};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {-5, -4, -3, -1, -1});
+  }
+
+  @Test
+  public void testMixedPositiveAndNegative() {
+    int[] array = {3, -2, 0, 7, -5, 1};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {-5, -2, 0, 1, 3, 7});
+  }
+
+  @Test
+  public void testTwoElements() {
+    int[] array = {9, 1};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {1, 9});
+  }
+
+  @Test
+  public void testStaticMergesortMethod() {
+    int[] array = {10, 4, 6, 4, 8, -13, 2, 3};
+    int[] result = MergeSort.mergesort(array);
+    assertThat(result).isEqualTo(new int[] {-13, 2, 3, 4, 4, 6, 8, 10});
+  }
+
+  @Test
+  public void testRandomized() {
+    for (int size = 0; size < 500; size++) {
+      int[] values = TestUtils.randomIntegerArray(size, -50, 51);
+      int[] expected = values.clone();
+      Arrays.sort(expected);
+      sorter.sort(values);
+      assertThat(values).isEqualTo(expected);
+    }
+  }
+}

--- a/src/test/java/com/williamfiset/algorithms/sorting/QuickSort3Test.java
+++ b/src/test/java/com/williamfiset/algorithms/sorting/QuickSort3Test.java
@@ -1,0 +1,94 @@
+package com.williamfiset.algorithms.sorting;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.williamfiset.algorithms.utils.TestUtils;
+import java.util.Arrays;
+import org.junit.jupiter.api.*;
+
+public class QuickSort3Test {
+
+  private final QuickSort3 sorter = new QuickSort3();
+
+  @Test
+  public void testEmptyArray() {
+    int[] array = {};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {});
+  }
+
+  @Test
+  public void testSingleElement() {
+    int[] array = {42};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {42});
+  }
+
+  @Test
+  public void testAlreadySorted() {
+    int[] array = {1, 2, 3, 4, 5};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {1, 2, 3, 4, 5});
+  }
+
+  @Test
+  public void testReverseSorted() {
+    int[] array = {5, 4, 3, 2, 1};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {1, 2, 3, 4, 5});
+  }
+
+  @Test
+  public void testWithDuplicates() {
+    int[] array = {10, 4, 6, 4, 8, -13, 2, 3};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {-13, 2, 3, 4, 4, 6, 8, 10});
+  }
+
+  @Test
+  public void testAllSameElements() {
+    int[] array = {5, 5, 5, 5, 5};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {5, 5, 5, 5, 5});
+  }
+
+  @Test
+  public void testManyDuplicates() {
+    // QuickSort3 is specifically optimized for arrays with few unique elements
+    int[] array = {2, 1, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3});
+  }
+
+  @Test
+  public void testNegativeNumbers() {
+    int[] array = {-3, -1, -4, -1, -5};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {-5, -4, -3, -1, -1});
+  }
+
+  @Test
+  public void testMixedPositiveAndNegative() {
+    int[] array = {3, -2, 0, 7, -5, 1};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {-5, -2, 0, 1, 3, 7});
+  }
+
+  @Test
+  public void testTwoElements() {
+    int[] array = {9, 1};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {1, 9});
+  }
+
+  @Test
+  public void testRandomized() {
+    for (int size = 0; size < 500; size++) {
+      int[] values = TestUtils.randomIntegerArray(size, -50, 51);
+      int[] expected = values.clone();
+      Arrays.sort(expected);
+      sorter.sort(values);
+      assertThat(values).isEqualTo(expected);
+    }
+  }
+}

--- a/src/test/java/com/williamfiset/algorithms/sorting/QuickSortTest.java
+++ b/src/test/java/com/williamfiset/algorithms/sorting/QuickSortTest.java
@@ -1,0 +1,86 @@
+package com.williamfiset.algorithms.sorting;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.williamfiset.algorithms.utils.TestUtils;
+import java.util.Arrays;
+import org.junit.jupiter.api.*;
+
+public class QuickSortTest {
+
+  private final QuickSort sorter = new QuickSort();
+
+  @Test
+  public void testEmptyArray() {
+    int[] array = {};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {});
+  }
+
+  @Test
+  public void testSingleElement() {
+    int[] array = {42};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {42});
+  }
+
+  @Test
+  public void testAlreadySorted() {
+    int[] array = {1, 2, 3, 4, 5};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {1, 2, 3, 4, 5});
+  }
+
+  @Test
+  public void testReverseSorted() {
+    int[] array = {5, 4, 3, 2, 1};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {1, 2, 3, 4, 5});
+  }
+
+  @Test
+  public void testWithDuplicates() {
+    int[] array = {10, 4, 6, 4, 8, -13, 2, 3};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {-13, 2, 3, 4, 4, 6, 8, 10});
+  }
+
+  @Test
+  public void testAllSameElements() {
+    int[] array = {5, 5, 5, 5, 5};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {5, 5, 5, 5, 5});
+  }
+
+  @Test
+  public void testNegativeNumbers() {
+    int[] array = {-3, -1, -4, -1, -5};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {-5, -4, -3, -1, -1});
+  }
+
+  @Test
+  public void testMixedPositiveAndNegative() {
+    int[] array = {3, -2, 0, 7, -5, 1};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {-5, -2, 0, 1, 3, 7});
+  }
+
+  @Test
+  public void testTwoElements() {
+    int[] array = {9, 1};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {1, 9});
+  }
+
+  @Test
+  public void testRandomized() {
+    for (int size = 0; size < 500; size++) {
+      int[] values = TestUtils.randomIntegerArray(size, -50, 51);
+      int[] expected = values.clone();
+      Arrays.sort(expected);
+      sorter.sort(values);
+      assertThat(values).isEqualTo(expected);
+    }
+  }
+}

--- a/src/test/java/com/williamfiset/algorithms/sorting/SelectionSortTest.java
+++ b/src/test/java/com/williamfiset/algorithms/sorting/SelectionSortTest.java
@@ -1,0 +1,86 @@
+package com.williamfiset.algorithms.sorting;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.williamfiset.algorithms.utils.TestUtils;
+import java.util.Arrays;
+import org.junit.jupiter.api.*;
+
+public class SelectionSortTest {
+
+  private final SelectionSort sorter = new SelectionSort();
+
+  @Test
+  public void testEmptyArray() {
+    int[] array = {};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {});
+  }
+
+  @Test
+  public void testSingleElement() {
+    int[] array = {42};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {42});
+  }
+
+  @Test
+  public void testAlreadySorted() {
+    int[] array = {1, 2, 3, 4, 5};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {1, 2, 3, 4, 5});
+  }
+
+  @Test
+  public void testReverseSorted() {
+    int[] array = {5, 4, 3, 2, 1};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {1, 2, 3, 4, 5});
+  }
+
+  @Test
+  public void testWithDuplicates() {
+    int[] array = {3, 1, 4, 1, 5, 9, 2, 6, 5, 3};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {1, 1, 2, 3, 3, 4, 5, 5, 6, 9});
+  }
+
+  @Test
+  public void testAllSameElements() {
+    int[] array = {8, 8, 8, 8};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {8, 8, 8, 8});
+  }
+
+  @Test
+  public void testNegativeNumbers() {
+    int[] array = {-3, -1, -4, -1, -5};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {-5, -4, -3, -1, -1});
+  }
+
+  @Test
+  public void testMixedPositiveAndNegative() {
+    int[] array = {3, -2, 0, 7, -5, 1};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {-5, -2, 0, 1, 3, 7});
+  }
+
+  @Test
+  public void testTwoElements() {
+    int[] array = {9, 1};
+    sorter.sort(array);
+    assertThat(array).isEqualTo(new int[] {1, 9});
+  }
+
+  @Test
+  public void testRandomized() {
+    for (int size = 0; size < 200; size++) {
+      int[] values = TestUtils.randomIntegerArray(size, -50, 51);
+      int[] expected = values.clone();
+      Arrays.sort(expected);
+      sorter.sort(values);
+      assertThat(values).isEqualTo(expected);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- **Fix BucketSort bug**: bucket index was dividing by `M` (range) instead of `N` (element count), causing all elements to land in bucket 0 and degrading to O(n log n)
- **Remove obsolete `./gradlew run` instructions** from all sorting algorithm javadocs (10 files)
- **Add dedicated test files** for BubbleSort, BucketSort, CountingSort, Heapsort, InsertionSort, MergeSort, QuickSort, QuickSort3, and SelectionSort — each with edge case and randomized tests

## Test plan
- [x] All 12 sorting test targets pass via `bazel test //src/test/java/.../sorting/...`
- [x] BucketSort bug fix verified by dedicated BucketSortTest (15 tests including randomized)
- [x] Existing SortingTest and RadixSortTest continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)