### PR TITLE
Refactor SuffixArraySlow and expand test coverage

### DIFF
--- a/src/main/java/com/williamfiset/algorithms/datastructures/suffixarray/SuffixArraySlow.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/suffixarray/SuffixArraySlow.java
@@ -1,31 +1,41 @@
+package com.williamfiset.algorithms.datastructures.suffixarray;
+
+import java.util.Arrays;
+
 /**
- * Naive suffix array implementation.
+ * Naive Suffix Array Construction
  *
- * <p>Time Complexity: O(n^2log(n))
+ * Builds a suffix array by generating all suffixes, sorting them with
+ * a standard comparison sort, and extracting the sorted indices.
+ * Simple to understand but slow for large inputs.
+ *
+ * Compare with SuffixArrayMed (O(n log^2 n)) and SuffixArrayFast (O(n log n))
+ * to see progressively more efficient construction algorithms.
+ *
+ * Time:  O(n^2 log n) — sorting is O(n log n) comparisons, each O(n)
+ * Space: O(n)
  *
  * @author William Fiset, william.alexandre.fiset@gmail.com
  */
-package com.williamfiset.algorithms.datastructures.suffixarray;
-
 public class SuffixArraySlow extends SuffixArray {
 
   private static class Suffix implements Comparable<Suffix> {
-    // Starting position of suffix in text
     final int index, len;
     final int[] text;
 
-    public Suffix(int[] text, int index) {
+    Suffix(int[] text, int index) {
       this.len = text.length - index;
       this.index = index;
       this.text = text;
     }
 
-    // Compare the two suffixes inspired by Robert Sedgewick and Kevin Wayne
+    // Lexicographic comparison of two suffixes, character by character.
+    // If one suffix is a prefix of the other, the shorter one comes first.
     @Override
     public int compareTo(Suffix other) {
       if (this == other) return 0;
-      int min_len = Math.min(len, other.len);
-      for (int i = 0; i < min_len; i++) {
+      int minLen = Math.min(len, other.len);
+      for (int i = 0; i < minLen; i++) {
         if (text[index + i] < other.text[other.index + i]) return -1;
         if (text[index + i] > other.text[other.index + i]) return +1;
       }
@@ -38,8 +48,7 @@ public class SuffixArraySlow extends SuffixArray {
     }
   }
 
-  // Contains all the suffixes of the SuffixArray
-  Suffix[] suffixes;
+  private Suffix[] suffixes;
 
   public SuffixArraySlow(String text) {
     super(toIntArray(text));
@@ -49,8 +58,10 @@ public class SuffixArraySlow extends SuffixArray {
     super(text);
   }
 
-  // Suffix array construction. This actually takes O(n^2log(n)) time since sorting takes on
-  // average O(nlog(n)) and each String comparison takes O(n).
+  /**
+   * Constructs the suffix array by creating all n suffixes, sorting
+   * them lexicographically, then storing the sorted starting indices.
+   */
   @Override
   protected void construct() {
     sa = new int[N];
@@ -58,12 +69,10 @@ public class SuffixArraySlow extends SuffixArray {
 
     for (int i = 0; i < N; i++) suffixes[i] = new Suffix(T, i);
 
-    java.util.Arrays.sort(suffixes);
+    Arrays.sort(suffixes);
 
     for (int i = 0; i < N; i++) {
-      Suffix suffix = suffixes[i];
-      sa[i] = suffix.index;
-      suffixes[i] = null;
+      sa[i] = suffixes[i].index;
     }
 
     suffixes = null;

--- a/src/test/java/com/williamfiset/algorithms/datastructures/suffixarray/SuffixArrayTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/suffixarray/SuffixArrayTest.java
@@ -1,49 +1,69 @@
 package com.williamfiset.algorithms.datastructures.suffixarray;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.security.SecureRandom;
 import java.util.Random;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.Test;
 
 public class SuffixArrayTest {
 
-  static final SecureRandom random = new SecureRandom();
-  static final Random rand = new Random();
+  static final String ASCII_LETTERS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
-  static final int LOOPS = 1000;
-  static final int TEST_SZ = 40;
-  static final int NUM_NULLS = TEST_SZ / 5;
-  static final int MAX_RAND_NUM = 250;
-
-  String ASCII_LETTERS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
-
-  @BeforeEach
-  public void setup() {}
-
-  @Test
-  public void suffixArrayLength() {
-    String str = "ABCDE";
-
-    SuffixArray sa1 = new SuffixArraySlow(str);
-    SuffixArray sa2 = new SuffixArrayMed(str);
-    SuffixArray sa3 = new SuffixArrayFast(str);
-
-    assertThat(sa1.getSa().length).isEqualTo(str.length());
-    assertThat(sa2.getSa().length).isEqualTo(str.length());
-    assertThat(sa3.getSa().length).isEqualTo(str.length());
+  // Helper: create all 3 implementations for the same text
+  private static SuffixArray[] allImplementations(String text) {
+    return new SuffixArray[] {
+      new SuffixArraySlow(text),
+      new SuffixArrayMed(text),
+      new SuffixArrayFast(text)
+    };
   }
 
   @Test
-  public void lcsUniqueCharacters() {
+  public void testNullTextThrows() {
+    assertThrows(IllegalArgumentException.class, () -> new SuffixArraySlow((int[]) null));
+    assertThrows(IllegalArgumentException.class, () -> new SuffixArrayMed((int[]) null));
+    assertThrows(IllegalArgumentException.class, () -> new SuffixArrayFast((int[]) null));
+  }
 
-    SuffixArray sa1 = new SuffixArraySlow(ASCII_LETTERS);
-    SuffixArray sa2 = new SuffixArrayMed(ASCII_LETTERS);
-    SuffixArray sa3 = new SuffixArrayFast(ASCII_LETTERS);
+  @Test
+  public void testSingleCharacter() {
+    for (SuffixArray sa : allImplementations("A")) {
+      assertThat(sa.getSa()).isEqualTo(new int[] {0});
+      assertThat(sa.getLcpArray()).isEqualTo(new int[] {0});
+    }
+  }
 
-    SuffixArray[] suffixArrays = {sa1, sa2, sa3};
+  @Test
+  public void testTwoCharactersSorted() {
+    // "AB" -> suffixes: "AB"(0), "B"(1) -> sorted: "AB","B" -> sa=[0,1]
+    for (SuffixArray sa : allImplementations("AB")) {
+      assertThat(sa.getSa()).isEqualTo(new int[] {0, 1});
+      assertThat(sa.getLcpArray()).isEqualTo(new int[] {0, 0});
+    }
+  }
 
-    for (SuffixArray sa : suffixArrays) {
+  @Test
+  public void testTwoCharactersReversed() {
+    // "BA" -> suffixes: "BA"(0), "A"(1) -> sorted: "A","BA" -> sa=[1,0]
+    for (SuffixArray sa : allImplementations("BA")) {
+      assertThat(sa.getSa()).isEqualTo(new int[] {1, 0});
+      assertThat(sa.getLcpArray()).isEqualTo(new int[] {0, 0});
+    }
+  }
+
+  @Test
+  public void testSuffixArrayLength() {
+    String str = "ABCDE";
+    for (SuffixArray sa : allImplementations(str)) {
+      assertThat(sa.getSa().length).isEqualTo(str.length());
+      assertThat(sa.getTextLength()).isEqualTo(str.length());
+    }
+  }
+
+  @Test
+  public void testLcpAllZerosForUniqueCharacters() {
+    for (SuffixArray sa : allImplementations(ASCII_LETTERS)) {
       for (int i = 0; i < sa.getSa().length; i++) {
         assertThat(sa.getLcpArray()[i]).isEqualTo(0);
       }
@@ -51,17 +71,10 @@ public class SuffixArrayTest {
   }
 
   @Test
-  public void increasingLCPTest() {
-
-    String UNIQUE_CHARS = "KKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKK";
-
-    SuffixArray sa1 = new SuffixArraySlow(UNIQUE_CHARS);
-    SuffixArray sa2 = new SuffixArrayMed(UNIQUE_CHARS);
-    SuffixArray sa3 = new SuffixArrayFast(UNIQUE_CHARS);
-
-    SuffixArray[] suffixArrays = {sa1, sa2, sa3};
-
-    for (SuffixArray sa : suffixArrays) {
+  public void testLcpIncreasingForRepeatedCharacter() {
+    // All same character: LCP[i] = i since suffixes are "KKK...", "KK...", "K..."
+    String repeated = "KKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKK";
+    for (SuffixArray sa : allImplementations(repeated)) {
       for (int i = 0; i < sa.getSa().length; i++) {
         assertThat(sa.getLcpArray()[i]).isEqualTo(i);
       }
@@ -69,60 +82,90 @@ public class SuffixArrayTest {
   }
 
   @Test
-  public void lcpTest1() {
-
+  public void testLcpKnownValues1() {
     String text = "ABBABAABAA";
-    int[] lcpValues = {0, 1, 2, 1, 4, 2, 0, 3, 2, 1};
-
-    SuffixArray sa1 = new SuffixArraySlow(text);
-    SuffixArray sa2 = new SuffixArrayMed(text);
-    SuffixArray sa3 = new SuffixArrayFast(text);
-
-    SuffixArray[] suffixArrays = {sa1, sa2, sa3};
-
-    for (SuffixArray sa : suffixArrays) {
-      for (int i = 0; i < sa.getSa().length; i++) {
-        assertThat(lcpValues[i]).isEqualTo(sa.getLcpArray()[i]);
-      }
+    int[] expected = {0, 1, 2, 1, 4, 2, 0, 3, 2, 1};
+    for (SuffixArray sa : allImplementations(text)) {
+      assertThat(sa.getLcpArray()).isEqualTo(expected);
     }
   }
 
   @Test
-  public void lcpTest2() {
+  public void testLcpKnownValues2() {
     String text = "ABABABAABB";
-    int[] lcpValues = {0, 1, 3, 5, 2, 0, 1, 2, 4, 1};
+    int[] expected = {0, 1, 3, 5, 2, 0, 1, 2, 4, 1};
+    for (SuffixArray sa : allImplementations(text)) {
+      assertThat(sa.getLcpArray()).isEqualTo(expected);
+    }
+  }
 
-    SuffixArray sa1 = new SuffixArraySlow(text);
-    SuffixArray sa2 = new SuffixArrayMed(text);
-    SuffixArray sa3 = new SuffixArrayFast(text);
-
-    SuffixArray[] suffixArrays = {sa1, sa2, sa3};
-
-    for (SuffixArray sa : suffixArrays) {
-      for (int i = 0; i < sa.getSa().length; i++) {
-        assertThat(lcpValues[i]).isEqualTo(sa.getLcpArray()[i]);
+  // Verify the suffix array actually produces lexicographically sorted suffixes
+  @Test
+  public void testSuffixesAreSorted() {
+    String text = "ABBABAABAA";
+    for (SuffixArray sa : allImplementations(text)) {
+      int[] arr = sa.getSa();
+      for (int i = 0; i < arr.length - 1; i++) {
+        String s1 = text.substring(arr[i]);
+        String s2 = text.substring(arr[i + 1]);
+        assertThat(s1.compareTo(s2)).isLessThan(0);
       }
     }
   }
 
   @Test
-  public void saConstruction() {
-    // Test inspired by LCS. Make sure constructed SAs are equal.
-    // Use digits 0-9 to fake unique tokens
+  public void testConstructionConsistency() {
+    // All 3 implementations must produce the same SA
     String text = "BAAAAB0ABAAAAB1BABA2ABA3AAB4BBBB5BB";
+    SuffixArray[] impls = allImplementations(text);
+    for (int i = 0; i < impls.length; i++) {
+      for (int j = i + 1; j < impls.length; j++) {
+        assertThat(impls[i].getSa()).isEqualTo(impls[j].getSa());
+      }
+    }
+  }
 
+  @Test
+  public void testIntArrayConstructor() {
+    // "CAB" as int array
+    int[] text = {67, 65, 66};
     SuffixArray sa1 = new SuffixArraySlow(text);
     SuffixArray sa2 = new SuffixArrayMed(text);
     SuffixArray sa3 = new SuffixArrayFast(text);
-    SuffixArray[] suffixArrays = {sa1, sa2, sa3};
 
-    for (int i = 0; i < suffixArrays.length; i++) {
-      for (int j = i + 1; j < suffixArrays.length; j++) {
-        SuffixArray s1 = suffixArrays[i];
-        SuffixArray s2 = suffixArrays[j];
-        for (int k = 0; k < s1.getSa().length; k++) {
-          assertThat(s1.getSa()[k]).isEqualTo(s2.getSa()[k]);
-        }
+    // Suffixes: "CAB"(0), "AB"(1), "B"(2) -> sorted: "AB","B","CAB" -> sa=[1,2,0]
+    int[] expected = {1, 2, 0};
+    assertThat(sa1.getSa()).isEqualTo(expected);
+    assertThat(sa2.getSa()).isEqualTo(expected);
+    assertThat(sa3.getSa()).isEqualTo(expected);
+  }
+
+  // Randomized cross-validation: all implementations must agree on random inputs
+  @Test
+  public void testRandomStringsAllImplementationsAgree() {
+    Random rand = new Random(42);
+    for (int loop = 0; loop < 200; loop++) {
+      int len = 2 + rand.nextInt(20);
+      StringBuilder sb = new StringBuilder();
+      for (int i = 0; i < len; i++) {
+        sb.append((char) ('A' + rand.nextInt(5)));
+      }
+      String text = sb.toString();
+
+      SuffixArray[] impls = allImplementations(text);
+
+      // All SAs must match
+      for (int i = 1; i < impls.length; i++) {
+        assertThat(impls[i].getSa()).isEqualTo(impls[0].getSa());
+        assertThat(impls[i].getLcpArray()).isEqualTo(impls[0].getLcpArray());
+      }
+
+      // Verify sorted order
+      int[] sa = impls[0].getSa();
+      for (int i = 0; i < sa.length - 1; i++) {
+        String s1 = text.substring(sa[i]);
+        String s2 = text.substring(sa[i + 1]);
+        assertThat(s1.compareTo(s2)).isLessThan(0);
       }
     }
   }


### PR DESCRIPTION
## Summary
- **Refactor SuffixArraySlow**: fix package declaration order, add file-level header with Big-O and comparison to faster variants, replace FQN `java.util.Arrays` with import, rename `min_len` to `minLen`, make `suffixes` field private, add Javadoc to `construct()`
- **Expand test coverage** (6 existing tests → 13 tests):
  - Null input validation
  - Single character and two character edge cases
  - `int[]` constructor (previously untested)
  - `getTextLength()` (previously untested)
  - Suffix sorted order verification (proves SA is correct, not just consistent)
  - Randomized cross-validation: 200 random strings verified across all 3 implementations for both SA and LCP agreement
- **Clean up test file**: remove unused fields (`SecureRandom`, `LOOPS`, `TEST_SZ`, etc.), empty `@BeforeEach`, wildcard import

## Test plan
- [x] All 13 tests pass across SuffixArraySlow, SuffixArrayMed, and SuffixArrayFast

🤖 Generated with [Claude Code](https://claude.com/claude-code)