### PR TITLE
Refactor Node segment tree: add docs, simplify, expand tests

### DIFF
--- a/src/main/java/com/williamfiset/algorithms/datastructures/segmenttree/Node.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/segmenttree/Node.java
@@ -1,23 +1,49 @@
+package com.williamfiset.algorithms.datastructures.segmenttree;
+
 /**
- * Segment Trees are an extremely useful data structure when dealing with ranges or intervals. They
- * take O(n) time and space to construct, but they can do range updates or queries in O(log(n))
- * time. This data structure is quite flexible; although the code below supports minimum and sum
- * queries, these could be modified to perform other types of queries. This implementation uses lazy
- * propagation (which allows for O(log(n)) range updates instead of O(n)). It should also be noted
- * that this implementation could easily be modified to support coordinate compression (you should
- * only have to change a few lines in the constructor).
+ * Pointer-Based Segment Tree with Lazy Propagation
+ *
+ * A segment tree built with explicit left/right child pointers (rather than
+ * a flat array). Supports range sum queries, range min queries, and range
+ * updates (add a value to every element in an interval), all in O(log(n)).
+ *
+ * Lazy propagation defers updates to child nodes until they are actually
+ * needed, keeping range updates at O(log(n)) instead of O(n).
+ *
+ * Each node covers a half-open interval [minPos, maxPos). Leaves cover a
+ * single element [i, i+1). The combine function computes both sum and min
+ * simultaneously as values propagate up.
+ *
+ * Use cases:
+ *   - Range sum / min queries with range add updates
+ *   - Problems requiring coordinate compression (easy to adapt constructor)
+ *
+ * Time:  O(n) construction, O(log(n)) per query and update
+ * Space: O(n)
  *
  * @author Micah Stairs
  */
-package com.williamfiset.algorithms.datastructures.segmenttree;
-
 public class Node {
 
-  static final int INF = Integer.MAX_VALUE;
+  private static final int INF = Integer.MAX_VALUE;
 
-  Node left, right;
-  int minPos, maxPos, min = 0, sum = 0, lazy = 0;
+  private Node left, right;
 
+  // This node covers the half-open interval [minPos, maxPos)
+  private int minPos, maxPos;
+
+  // Aggregate values for this node's range
+  private int min = 0, sum = 0;
+
+  // Pending update that hasn't been pushed to children yet
+  private int lazy = 0;
+
+  /**
+   * Creates a segment tree from an array of values.
+   *
+   * @param values the initial values for the leaves
+   * @throws IllegalArgumentException if values is null
+   */
   public Node(int[] values) {
     if (values == null) throw new IllegalArgumentException("Null input to segment tree.");
     buildTree(0, values.length);
@@ -26,113 +52,110 @@ public class Node {
     }
   }
 
+  /**
+   * Creates an empty segment tree of the given size, with all values at 0.
+   *
+   * @param sz the number of elements
+   */
   public Node(int sz) {
     buildTree(0, sz);
   }
 
-  private Node(int l, int r) {
-    buildTree(l, r);
-  }
-
-  // Recursive method that builds the segment tree
+  // Recursively builds the tree structure for the range [l, r).
+  // Leaves cover [i, i+1); internal nodes split at the midpoint.
   private void buildTree(int l, int r) {
-
     if (l < 0 || r < 0 || r < l)
       throw new IllegalArgumentException("Illegal range: (" + l + "," + r + ")");
 
     minPos = l;
     maxPos = r;
 
-    // Reached leaf
-    if (l == r - 1) {
-      left = right = null;
-
-      // Add children
-    } else {
+    // Internal node — split at midpoint
+    if (r - l > 1) {
       int mid = (l + r) / 2;
       left = new Node(l, mid);
       right = new Node(mid, r);
     }
   }
 
-  // Adjust all values in the interval [l, r) by a particular amount
-  public void update(int l, int r, int change) {
+  private Node(int l, int r) {
+    buildTree(l, r);
+  }
 
-    // Do lazy updates to children
+  /**
+   * Adds {@code change} to every element in the half-open interval [l, r).
+   *
+   * @param l      left endpoint (inclusive)
+   * @param r      right endpoint (exclusive)
+   * @param change the value to add to each element in [l, r)
+   *
+   * Time: O(log(n))
+   */
+  public void update(int l, int r, int change) {
     propagate();
 
-    // Node's range fits inside query range
     if (l <= minPos && maxPos <= r) {
-
+      // Fully inside — apply update directly
       sum += change * (maxPos - minPos);
       min += change;
-
-      // Lazily propagate update to children
+      // Lazily defer to children
       if (left != null) left.lazy += change;
       if (right != null) right.lazy += change;
-
-      // Ranges do not overlap
     } else if (r <= minPos || l >= maxPos) {
-
-      // Do nothing
-
-      // Ranges partially overlap
+      // No overlap
     } else {
-
-      if (left != null) left.update(l, r, change);
-      if (right != null) right.update(l, r, change);
-      sum = (left == null ? 0 : left.sum) + (right == null ? 0 : right.sum);
-      min = Math.min((left == null ? INF : left.min), (right == null ? INF : right.min));
+      // Partial overlap — recurse into children.
+      // Partial overlap only happens at internal nodes (leaves always
+      // fully match or fully miss), so left and right are never null here.
+      left.update(l, r, change);
+      right.update(l, r, change);
+      sum = left.sum + right.sum;
+      min = Math.min(left.min, right.min);
     }
   }
 
-  // Get the sum in the interval [l, r)
+  /**
+   * Returns the sum of elements in the half-open interval [l, r).
+   *
+   * @param l left endpoint (inclusive)
+   * @param r right endpoint (exclusive)
+   * @return the sum of all elements in [l, r)
+   *
+   * Time: O(log(n))
+   */
   public int sum(int l, int r) {
-
-    // Do lazy updates to children
     propagate();
-
-    // Node's range fits inside query range
     if (l <= minPos && maxPos <= r) return sum;
-
-    // Ranges do not overlap
-    else if (r <= minPos || l >= maxPos) return 0;
-
-    // Ranges partially overlap
-    else return (left == null ? 0 : left.sum(l, r)) + (right == null ? 0 : right.sum(l, r));
+    if (r <= minPos || l >= maxPos) return 0;
+    return left.sum(l, r) + right.sum(l, r);
   }
 
-  // Get the minimum value in the interval [l, r)
+  /**
+   * Returns the minimum element in the half-open interval [l, r).
+   *
+   * @param l left endpoint (inclusive)
+   * @param r right endpoint (exclusive)
+   * @return the minimum value in [l, r)
+   *
+   * Time: O(log(n))
+   */
   public int min(int l, int r) {
-
-    // Do lazy updates to children
     propagate();
-
-    // Node's range fits inside query range
     if (l <= minPos && maxPos <= r) return min;
-
-    // Ranges do not overlap
-    else if (r <= minPos || l >= maxPos) return INF;
-
-    // Ranges partially overlap
-    else
-      return Math.min(
-          (left == null ? INF : left.min(l, r)), (right == null ? INF : right.min(l, r)));
+    if (r <= minPos || l >= maxPos) return INF;
+    return Math.min(left.min(l, r), right.min(l, r));
   }
 
-  // Does any updates to this node that haven't been done yet, and lazily updates its children
-  // NOTE: This method must be called before updating or accessing a node
+  /**
+   * Applies any pending lazy update to this node and defers it to children.
+   * Must be called before reading or modifying a node's values.
+   */
   private void propagate() {
-
     if (lazy != 0) {
-
       sum += lazy * (maxPos - minPos);
       min += lazy;
-
-      // Lazily propagate updates to children
       if (left != null) left.lazy += lazy;
       if (right != null) right.lazy += lazy;
-
       lazy = 0;
     }
   }

--- a/src/test/java/com/williamfiset/algorithms/datastructures/segmenttree/SegmentTreeWithPointersTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/segmenttree/SegmentTreeWithPointersTest.java
@@ -5,44 +5,100 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.williamfiset.algorithms.utils.TestUtils;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.Test;
 
 public class SegmentTreeWithPointersTest {
 
-  @BeforeEach
-  public void setup() {}
-
   @Test
-  public void testIllegalSegmentTreeCreation1() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> {
-          Node tree = new Node(null);
-        });
+  public void testNullInputThrows() {
+    assertThrows(IllegalArgumentException.class, () -> new Node(null));
   }
 
   @Test
-  public void testIllegalSegmentTreeCreation2() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> {
-          int size = -10;
-          Node tree = new Node(size);
-        });
+  public void testNegativeSizeThrows() {
+    assertThrows(IllegalArgumentException.class, () -> new Node(-10));
   }
 
   @Test
-  public void testSumQuery() {
+  public void testSingleElement() {
+    int[] values = {7};
+    Node tree = new Node(values);
+    assertThat(tree.sum(0, 1)).isEqualTo(7);
+    assertThat(tree.min(0, 1)).isEqualTo(7);
+  }
+
+  @Test
+  public void testSumQuerySingleElements() {
+    int[] values = {1, 2, 3, 4, 5};
+    Node tree = new Node(values);
+    for (int i = 0; i < values.length; i++) {
+      assertThat(tree.sum(i, i + 1)).isEqualTo(values[i]);
+    }
+  }
+
+  @Test
+  public void testSumQueryFullRange() {
+    int[] values = {1, 2, 3, 4, 5};
+    Node tree = new Node(values);
+    assertThat(tree.sum(0, 5)).isEqualTo(15);
+  }
+
+  @Test
+  public void testMinQuerySingleElements() {
+    int[] values = {5, 1, 3, 2, 4};
+    Node tree = new Node(values);
+    for (int i = 0; i < values.length; i++) {
+      assertThat(tree.min(i, i + 1)).isEqualTo(values[i]);
+    }
+  }
+
+  @Test
+  public void testMinQueryFullRange() {
+    int[] values = {5, 1, 3, 2, 4};
+    Node tree = new Node(values);
+    assertThat(tree.min(0, 5)).isEqualTo(1);
+    assertThat(tree.min(0, 2)).isEqualTo(1);
+    assertThat(tree.min(2, 5)).isEqualTo(2);
+  }
+
+  @Test
+  public void testRangeUpdate() {
     int[] values = {1, 2, 3, 4, 5};
     Node tree = new Node(values);
 
-    assertThat(tree.sum(0, 1)).isEqualTo(1);
-    assertThat(tree.sum(1, 2)).isEqualTo(2);
-    assertThat(tree.sum(2, 3)).isEqualTo(3);
-    assertThat(tree.sum(3, 4)).isEqualTo(4);
-    assertThat(tree.sum(4, 5)).isEqualTo(5);
+    // Add 10 to elements in [1, 4): values become {1, 12, 13, 14, 5}
+    tree.update(1, 4, 10);
+    assertThat(tree.sum(0, 5)).isEqualTo(45);
+    assertThat(tree.sum(1, 4)).isEqualTo(39);
+    assertThat(tree.min(0, 5)).isEqualTo(1);
+    assertThat(tree.min(1, 4)).isEqualTo(12);
   }
 
+  @Test
+  public void testNegativeValues() {
+    int[] values = {-3, -1, -4, -1, -5};
+    Node tree = new Node(values);
+    assertThat(tree.sum(0, 5)).isEqualTo(-14);
+    assertThat(tree.min(0, 5)).isEqualTo(-5);
+    assertThat(tree.min(0, 3)).isEqualTo(-4);
+  }
+
+  @Test
+  public void testMultipleUpdates() {
+    Node tree = new Node(5);
+    // Start with all zeros, add 1 to entire range
+    tree.update(0, 5, 1);
+    assertThat(tree.sum(0, 5)).isEqualTo(5);
+    assertThat(tree.min(0, 5)).isEqualTo(1);
+
+    // Add 2 to [2, 4): values become {1, 1, 3, 3, 1}
+    tree.update(2, 4, 2);
+    assertThat(tree.sum(0, 5)).isEqualTo(9);
+    assertThat(tree.min(0, 5)).isEqualTo(1);
+    assertThat(tree.min(2, 4)).isEqualTo(3);
+  }
+
+  // Brute-force cross-validation for sum queries on random data
   @Test
   public void testAllSumQueries() {
     int n = 100;
@@ -58,12 +114,31 @@ public class SegmentTreeWithPointersTest {
     }
   }
 
-  // Finds the sum in an array between [l, r) in the `values` array
+  // Brute-force cross-validation for min queries on random data
+  @Test
+  public void testAllMinQueries() {
+    int n = 100;
+    int[] ar = TestUtils.randomIntegerArray(n, -1000, +1000);
+    Node tree = new Node(ar);
+
+    for (int i = 0; i < n; i++) {
+      for (int j = i + 1; j < n; j++) {
+        int bfMin = bruteForceMin(ar, i, j);
+        int segTreeMin = tree.min(i, j);
+        assertThat(bfMin).isEqualTo(segTreeMin);
+      }
+    }
+  }
+
   private static long bruteForceSum(int[] values, int l, int r) {
     long s = 0;
-    for (int i = l; i < r; i++) {
-      s += values[i];
-    }
+    for (int i = l; i < r; i++) s += values[i];
     return s;
+  }
+
+  private static int bruteForceMin(int[] values, int l, int r) {
+    int m = Integer.MAX_VALUE;
+    for (int i = l; i < r; i++) m = Math.min(m, values[i]);
+    return m;
   }
 }


### PR DESCRIPTION
## Summary
- Add detailed file-level header explaining lazy propagation and tree layout
- Fix package/header order, make all fields private, add Javadoc on public methods
- Remove 9 unnecessary null checks in `update()`/`sum()`/`min()` — partial overlap only occurs at internal nodes where children are guaranteed non-null
- Simplify `buildTree`: invert leaf condition, remove redundant `left = right = null`
- Expand tests from 4 to 12: min queries, range updates, negative values, multiple updates, brute-force min cross-validation

## Test plan
- [x] All 12 tests pass (`bazel test ...segmenttree:SegmentTreeWithPointersTest`)
- [x] Brute-force cross-validation for both sum and min on 100-element random arrays

🤖 Generated with [Claude Code](https://claude.com/claude-code)