### PR TITLE
Refactor HashTableSeparateChaining: encapsulate Entry, fix iterator, simplify API

### DIFF
--- a/src/main/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableSeparateChaining.java
+++ b/src/main/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableSeparateChaining.java
@@ -1,5 +1,9 @@
 /**
- * An implementation of a hash-table using separate chaining with a linked list.
+ * A hash table implementation using separate chaining with linked lists.
+ *
+ * Each bucket holds a linked list of entries. On collision, new entries are appended to the list.
+ * When the load factor threshold is exceeded, the table doubles in capacity and all entries are
+ * rehashed.
  *
  * @author William Fiset, william.alexandre.fiset@gmail.com
  */
@@ -7,46 +11,38 @@ package com.williamfiset.algorithms.datastructures.hashtable;
 
 import java.util.*;
 
-class Entry<K, V> {
-
-  int hash;
-  K key;
-  V value;
-
-  public Entry(K key, V value) {
-    this.key = key;
-    this.value = value;
-    this.hash = key.hashCode();
-  }
-
-  @Override
-  public int hashCode() {
-    return hash;
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) return true;
-    if (obj == null || getClass() != obj.getClass()) return false;
-    Entry<?, ?> other = (Entry<?, ?>) obj;
-    if (hash != other.hash) return false;
-    return key.equals(other.key);
-  }
-
-  @Override
-  public String toString() {
-    return key + " => " + value;
-  }
-}
-
 @SuppressWarnings("unchecked")
 public class HashTableSeparateChaining<K, V> implements Iterable<K> {
+
+  private static class Entry<K, V> {
+    int hash;
+    K key;
+    V value;
+
+    // Cache the hash code so we don't recompute it on every resize
+    Entry(K key, V value) {
+      this.key = key;
+      this.value = value;
+      this.hash = key.hashCode();
+    }
+
+    boolean keyEquals(K other) {
+      return key.equals(other);
+    }
+
+    @Override
+    public String toString() {
+      return key + " => " + value;
+    }
+  }
 
   private static final int DEFAULT_CAPACITY = 3;
   private static final double DEFAULT_LOAD_FACTOR = 0.75;
 
   private double maxLoadFactor;
-  private int capacity, threshold, size = 0;
+  private int capacity, threshold, size;
+  // Tracks structural modifications for fail-fast iteration
+  private int modCount;
   private LinkedList<Entry<K, V>>[] table;
 
   public HashTableSeparateChaining() {
@@ -57,9 +53,9 @@ public class HashTableSeparateChaining<K, V> implements Iterable<K> {
     this(capacity, DEFAULT_LOAD_FACTOR);
   }
 
-  // Designated constructor
   public HashTableSeparateChaining(int capacity, double maxLoadFactor) {
-    if (capacity < 0) throw new IllegalArgumentException("Illegal capacity");
+    if (capacity < 0)
+      throw new IllegalArgumentException("Illegal capacity");
     if (maxLoadFactor <= 0 || Double.isNaN(maxLoadFactor) || Double.isInfinite(maxLoadFactor))
       throw new IllegalArgumentException("Illegal maxLoadFactor");
     this.maxLoadFactor = maxLoadFactor;
@@ -68,210 +64,197 @@ public class HashTableSeparateChaining<K, V> implements Iterable<K> {
     table = new LinkedList[this.capacity];
   }
 
-  // Returns the number of elements currently inside the hash-table
   public int size() {
     return size;
   }
 
-  // Returns true/false depending on whether the hash-table is empty
   public boolean isEmpty() {
     return size == 0;
   }
 
-  // Converts a hash value to an index. Essentially, this strips the
-  // negative sign and places the hash value in the domain [0, capacity)
+  // Strips the negative sign and maps the hash into [0, capacity)
   private int normalizeIndex(int keyHash) {
     return (keyHash & 0x7FFFFFFF) % capacity;
   }
 
-  // Clears all the contents of the hash-table
   public void clear() {
     Arrays.fill(table, null);
     size = 0;
+    modCount++;
   }
 
   public boolean containsKey(K key) {
-    return hasKey(key);
-  }
-
-  // Returns true/false depending on whether a key is in the hash table
-  public boolean hasKey(K key) {
     int bucketIndex = normalizeIndex(key.hashCode());
-    return bucketSeekEntry(bucketIndex, key) != null;
+    return seekEntry(bucketIndex, key) != null;
   }
 
-  // Insert, put and add all place a value in the hash-table
   public V put(K key, V value) {
-    return insert(key, value);
-  }
-
-  public V add(K key, V value) {
-    return insert(key, value);
-  }
-
-  public V insert(K key, V value) {
-    if (key == null) throw new IllegalArgumentException("Null key");
+    if (key == null)
+      throw new IllegalArgumentException("Null key");
     Entry<K, V> newEntry = new Entry<>(key, value);
     int bucketIndex = normalizeIndex(newEntry.hash);
-    return bucketInsertEntry(bucketIndex, newEntry);
+    return insertEntry(bucketIndex, newEntry);
   }
 
-  // Gets a key's values from the map and returns the value.
-  // NOTE: returns null if the value is null AND also returns
-  // null if the key does not exists, so watch out..
   public V get(K key) {
-    if (key == null) return null;
+    if (key == null)
+      return null;
     int bucketIndex = normalizeIndex(key.hashCode());
-    Entry<K, V> entry = bucketSeekEntry(bucketIndex, key);
-    if (entry != null) return entry.value;
-    return null;
+    Entry<K, V> entry = seekEntry(bucketIndex, key);
+    return entry != null ? entry.value : null;
   }
 
-  // Removes a key from the map and returns the value.
-  // NOTE: returns null if the value is null AND also returns
-  // null if the key does not exists.
   public V remove(K key) {
-    if (key == null) return null;
+    if (key == null)
+      return null;
     int bucketIndex = normalizeIndex(key.hashCode());
-    return bucketRemoveEntry(bucketIndex, key);
+    return removeEntry(bucketIndex, key);
   }
 
-  // Removes an entry from a given bucket if it exists
-  private V bucketRemoveEntry(int bucketIndex, K key) {
-    Entry<K, V> entry = bucketSeekEntry(bucketIndex, key);
-    if (entry != null) {
-      LinkedList<Entry<K, V>> links = table[bucketIndex];
-      links.remove(entry);
-      --size;
-      return entry.value;
-    } else return null;
-  }
-
-  // Inserts an entry in a given bucket only if the entry does not already
-  // exist in the given bucket, but if it does then update the entry value
-  private V bucketInsertEntry(int bucketIndex, Entry<K, V> entry) {
+  // Single-pass find-and-remove using an iterator to avoid scanning the bucket twice
+  private V removeEntry(int bucketIndex, K key) {
     LinkedList<Entry<K, V>> bucket = table[bucketIndex];
-    if (bucket == null) table[bucketIndex] = bucket = new LinkedList<>();
-
-    Entry<K, V> existentEntry = bucketSeekEntry(bucketIndex, entry.key);
-    if (existentEntry == null) {
-      bucket.add(entry);
-      if (++size > threshold) resizeTable();
-      return null; // Use null to indicate that there was no previous entry
-    } else {
-      V oldVal = existentEntry.value;
-      existentEntry.value = entry.value;
-      return oldVal;
+    if (bucket == null)
+      return null;
+    java.util.Iterator<Entry<K, V>> iter = bucket.iterator();
+    while (iter.hasNext()) {
+      Entry<K, V> entry = iter.next();
+      if (entry.keyEquals(key)) {
+        iter.remove();
+        size--;
+        modCount++;
+        return entry.value;
+      }
     }
-  }
-
-  // Finds and returns a particular entry in a given bucket if it exists, returns null otherwise
-  private Entry<K, V> bucketSeekEntry(int bucketIndex, K key) {
-    if (key == null) return null;
-    LinkedList<Entry<K, V>> bucket = table[bucketIndex];
-    if (bucket == null) return null;
-    for (Entry<K, V> entry : bucket) if (entry.key.equals(key)) return entry;
     return null;
   }
 
-  // Resizes the internal table holding buckets of entries
+  // If the key already exists, update its value and return the old value.
+  // Otherwise, insert a new entry and return null.
+  private V insertEntry(int bucketIndex, Entry<K, V> entry) {
+    LinkedList<Entry<K, V>> bucket = table[bucketIndex];
+    if (bucket == null)
+      table[bucketIndex] = bucket = new LinkedList<>();
+
+    Entry<K, V> existing = seekEntry(bucketIndex, entry.key);
+    if (existing == null) {
+      bucket.add(entry);
+      if (++size > threshold)
+        resizeTable();
+      modCount++;
+      return null;
+    }
+    V oldVal = existing.value;
+    existing.value = entry.value;
+    return oldVal;
+  }
+
+  // Linearly scans the bucket's chain looking for a matching key
+  private Entry<K, V> seekEntry(int bucketIndex, K key) {
+    if (key == null)
+      return null;
+    LinkedList<Entry<K, V>> bucket = table[bucketIndex];
+    if (bucket == null)
+      return null;
+    for (Entry<K, V> entry : bucket) {
+      if (entry.keyEquals(key))
+        return entry;
+    }
+    return null;
+  }
+
+  // Doubles the table capacity and rehashes all entries into new buckets
   private void resizeTable() {
     capacity *= 2;
     threshold = (int) (capacity * maxLoadFactor);
-
     LinkedList<Entry<K, V>>[] newTable = new LinkedList[capacity];
 
-    for (int i = 0; i < table.length; i++) {
-      if (table[i] != null) {
-        for (Entry<K, V> entry : table[i]) {
-          int bucketIndex = normalizeIndex(entry.hash);
-          LinkedList<Entry<K, V>> bucket = newTable[bucketIndex];
-          if (bucket == null) newTable[bucketIndex] = bucket = new LinkedList<>();
-          bucket.add(entry);
-        }
-
-        // Avoid memory leak. Help the GC
-        table[i].clear();
-        table[i] = null;
+    for (LinkedList<Entry<K, V>> bucket : table) {
+      if (bucket == null)
+        continue;
+      for (Entry<K, V> entry : bucket) {
+        int i = normalizeIndex(entry.hash);
+        if (newTable[i] == null)
+          newTable[i] = new LinkedList<>();
+        newTable[i].add(entry);
       }
     }
     table = newTable;
   }
 
-  // Returns the list of keys found within the hash table
   public List<K> keys() {
-    List<K> keys = new ArrayList<>(size());
-    for (LinkedList<Entry<K, V>> bucket : table)
-      if (bucket != null) for (Entry<K, V> entry : bucket) keys.add(entry.key);
+    List<K> keys = new ArrayList<>(size);
+    for (LinkedList<Entry<K, V>> bucket : table) {
+      if (bucket != null)
+        for (Entry<K, V> entry : bucket)
+          keys.add(entry.key);
+    }
     return keys;
   }
 
-  // Returns the list of values found within the hash table
   public List<V> values() {
-    List<V> values = new ArrayList<>(size());
-    for (LinkedList<Entry<K, V>> bucket : table)
-      if (bucket != null) for (Entry<K, V> entry : bucket) values.add(entry.value);
+    List<V> values = new ArrayList<>(size);
+    for (LinkedList<Entry<K, V>> bucket : table) {
+      if (bucket != null)
+        for (Entry<K, V> entry : bucket)
+          values.add(entry.value);
+    }
     return values;
   }
 
-  // Return an iterator to iterate over all the keys in this map
   @Override
-  public java.util.Iterator<K> iterator() {
-    final int MODIFICATION_COUNT = size; // Using size as a proxy for modifications for now, but better to have a dedicated counter
-    return new java.util.Iterator<K>() {
+  public Iterator<K> iterator() {
+    return new Iterator<K>() {
+      final int expectedModCount = modCount;
       int bucketIndex = 0;
-      java.util.Iterator<Entry<K, V>> bucketIter = (table[0] == null) ? null : table[0].iterator();
+      Iterator<Entry<K, V>> bucketIter = advanceToNextBucket();
+
+      private Iterator<Entry<K, V>> advanceToNextBucket() {
+        while (bucketIndex < capacity) {
+          if (table[bucketIndex] != null && !table[bucketIndex].isEmpty())
+            return table[bucketIndex].iterator();
+          bucketIndex++;
+        }
+        return null;
+      }
 
       @Override
       public boolean hasNext() {
-        // An item was added or removed while iterating
-        if (MODIFICATION_COUNT != size) throw new java.util.ConcurrentModificationException();
-
-        // No iterator or the current iterator is empty
-        if (bucketIter == null || !bucketIter.hasNext()) {
-          // Search next buckets until a valid iterator is found
-          while (++bucketIndex < capacity) {
-            if (table[bucketIndex] != null) {
-              // Make sure this iterator actually has elements -_-
-              java.util.Iterator<Entry<K, V>> nextIter = table[bucketIndex].iterator();
-              if (nextIter.hasNext()) {
-                bucketIter = nextIter;
-                break;
-              }
-            }
-          }
-        }
-        return bucketIndex < capacity;
+        if (expectedModCount != modCount)
+          throw new ConcurrentModificationException();
+        return bucketIter != null && bucketIter.hasNext();
       }
 
       @Override
       public K next() {
-        if (!hasNext()) throw new NoSuchElementException();
-        return bucketIter.next().key;
-      }
-
-      @Override
-      public void remove() {
-        throw new UnsupportedOperationException();
+        if (expectedModCount != modCount)
+          throw new ConcurrentModificationException();
+        if (bucketIter == null || !bucketIter.hasNext())
+          throw new NoSuchElementException();
+        K key = bucketIter.next().key;
+        if (!bucketIter.hasNext()) {
+          bucketIndex++;
+          bucketIter = advanceToNextBucket();
+        }
+        return key;
       }
     };
   }
 
-  // Returns a string representation of this hash table
   @Override
   public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("{");
+    StringBuilder sb = new StringBuilder("{");
     boolean first = true;
-    for (int i = 0; i < capacity; i++) {
-      if (table[i] == null) continue;
-      for (Entry<K, V> entry : table[i]) {
-        if (!first) sb.append(", ");
+    for (LinkedList<Entry<K, V>> bucket : table) {
+      if (bucket == null)
+        continue;
+      for (Entry<K, V> entry : bucket) {
+        if (!first)
+          sb.append(", ");
         sb.append(entry);
         first = false;
       }
     }
-    sb.append("}");
-    return sb.toString();
+    return sb.append("}").toString();
   }
 }

--- a/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableSeparateChainingTest.java
+++ b/src/test/java/com/williamfiset/algorithms/datastructures/hashtable/HashTableSeparateChainingTest.java
@@ -135,13 +135,13 @@ public class HashTableSeparateChainingTest {
       map = new HashTableSeparateChaining<>();
 
       List<Integer> rand_nums = genRandList(MAX_SIZE);
-      for (Integer key : rand_nums) assertThat(map.add(key, key)).isEqualTo(map2.put(key, key));
+      for (Integer key : rand_nums) assertThat(map.put(key, key)).isEqualTo(map2.put(key, key));
 
       int count = 0;
       for (Integer key : map) {
         assertThat(map.get(key)).isEqualTo(key);
         assertThat(map.get(key)).isEqualTo(map2.get(key));
-        assertThat(map.hasKey(key)).isTrue();
+        assertThat(map.containsKey(key)).isTrue();
         assertThat(rand_nums.contains(key)).isTrue();
         count++;
       }
@@ -163,10 +163,10 @@ public class HashTableSeparateChainingTest {
     assertThrows(
         ConcurrentModificationException.class,
         () -> {
-          map.add(1, 1);
-          map.add(2, 1);
-          map.add(3, 1);
-          for (Integer key : map) map.add(4, 4);
+          map.put(1, 1);
+          map.put(2, 1);
+          map.put(3, 1);
+          for (Integer key : map) map.put(4, 4);
         });
   }
 
@@ -175,9 +175,9 @@ public class HashTableSeparateChainingTest {
     assertThrows(
         ConcurrentModificationException.class,
         () -> {
-          map.add(1, 1);
-          map.add(2, 1);
-          map.add(3, 1);
+          map.put(1, 1);
+          map.put(2, 1);
+          map.put(3, 1);
           for (Integer key : map) map.remove(2);
         });
   }
@@ -245,10 +245,10 @@ public class HashTableSeparateChainingTest {
     HashObject o3 = new HashObject(88, 3);
     HashObject o4 = new HashObject(88, 4);
 
-    map.add(o1, 111);
-    map.add(o2, 111);
-    map.add(o3, 111);
-    map.add(o4, 111);
+    map.put(o1, 111);
+    map.put(o2, 111);
+    map.put(o3, 111);
+    map.put(o4, 111);
 
     map.remove(o2);
     map.remove(o3);


### PR DESCRIPTION
## Summary
- Make `Entry` a private static inner class instead of top-level package-private
- Remove redundant method aliases (`add`/`insert`/`hasKey`) — keep `put`/`containsKey`
- Add dedicated `modCount` for fail-fast iteration (was using `size` as proxy)
- Rewrite iterator so `hasNext()` is idempotent and doesn't advance state
- Use single-pass iterator removal in `removeEntry` to avoid double linear scan
- Remove unnecessary `bucket.clear()` in `resizeTable`
- Add educational comments on key implementation details

## Test plan
- [x] `bazel test //src/test/java/com/williamfiset/algorithms/datastructures/hashtable:HashTableSeparateChainingTest` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)